### PR TITLE
Add deploy script for container rebuilds

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# Determine persistent storage location
+if [[ "$OS" == "Windows_NT" ]]; then
+  PERSIST_DIR="${USERPROFILE//\\/\//}/Documents/vps-value-calculator"
+else
+  PERSIST_DIR="/opt/vps-value-calculator"
+fi
+export PERSIST_DIR
+mkdir -p "$PERSIST_DIR/data" "$PERSIST_DIR/static/images"
+
+# Clean repository and pull the latest code
+git reset --hard
+git clean -fd
+git pull
+
+# Stop existing containers
+docker-compose down
+
+# Remove dangling images
+docker image prune -f
+
+# Pull and rebuild images
+docker-compose pull
+docker-compose build --pull
+
+# Start services in detached mode
+docker-compose up -d
+
+# Optional: remove unused data
+# docker system prune -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,6 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - ./data:/app/data
-      - ./static/images:/app/static/images
+      - "${PERSIST_DIR}/data:/app/data"
+      - "${PERSIST_DIR}/static/images:/app/static/images"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add deploy script that resets repository, pulls latest changes and rebuilds containers
- set persistent storage path to `/opt` on Linux and `Documents` on Windows
- map docker volumes to the persistent directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ef64a5d00832a852b5fba521b3f8b