### PR TITLE
docs: add deploy script usage and update port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
-EXPOSE 8080
+EXPOSE 8280
 CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -66,8 +66,19 @@ docker compose up -d
 访问示例：
 
 ```
-http://your-server-ip:8080/vps/xxxx.svg
+http://your-server-ip:8280/vps/xxxx.svg
 ```
+
+### 🚀 使用部署脚本
+
+仓库提供 `deploy.sh` 脚本实现一键部署或更新：
+
+```bash
+chmod +x deploy.sh
+./deploy.sh
+```
+
+脚本会自动设置持久化目录、拉取最新代码并通过 `docker compose` 重建并启动服务。
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -62,4 +62,4 @@ def get_vps_image(name: str):
 
 if __name__ == "__main__":
     refresh_images()
-    app.run(host="0.0.0.0", port=8080)
+    app.run(host="0.0.0.0", port=8280)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   web:
     build: .
     ports:
-      - "8080:8080"
+      - "8280:8280"
     volumes:
       - "${PERSIST_DIR}/data:/app/data"
       - "${PERSIST_DIR}/static/images:/app/static/images"


### PR DESCRIPTION
## Summary
- document how to use `deploy.sh`
- change service port to 8280 in app and container configs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688ef8084430832a82a4c7881a8ab26b