### PR TITLE
Add user registration and admin management

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Another VPS value calculation
 
 
 
+## User Registration
+
+The application now includes a simple user system. The first user to register
+is automatically granted administrator privileges and can manage subsequent
+accounts.
+
+
 # 💰 VPS 剩余价值计算器
 
 一个专为 **VPS 交易** 场景设计的可视化剩余价值计算工具。通过自动计算、图片展示与链接分享，帮助你高效管理、展示、交易 VPS 资源。

--- a/app.py
+++ b/app.py
@@ -1,14 +1,60 @@
-from flask import Flask, send_from_directory, abort, render_template
+from flask import (
+    Flask,
+    send_from_directory,
+    abort,
+    render_template,
+    request,
+    redirect,
+    url_for,
+    session,
+)
+from werkzeug.security import generate_password_hash, check_password_hash
+from functools import wraps
 from sqlalchemy.orm import Session
 from apscheduler.schedulers.background import BackgroundScheduler
 from datetime import date
 
 from app.db import engine, Base
-from app.models import VPS
+from app.models import VPS, User
 from app.utils import calculate_remaining, generate_svg
 
 app = Flask(__name__)
+app.secret_key = "change-me"
 Base.metadata.create_all(bind=engine)
+
+
+def get_current_user():
+    user_id = session.get("user_id")
+    if user_id:
+        with Session(engine) as db:
+            return db.get(User, user_id)
+    return None
+
+
+def login_required(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if not session.get("user_id"):
+            return redirect(url_for("login"))
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+def admin_required(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        user = get_current_user()
+        if not user or not user.is_admin:
+            abort(403)
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+@app.context_processor
+def inject_user():
+    return {"current_user": get_current_user()}
 
 
 def init_sample():
@@ -39,6 +85,66 @@ def refresh_images():
 scheduler = BackgroundScheduler(timezone="UTC")
 scheduler.add_job(refresh_images, "cron", hour=0, minute=0)
 scheduler.start()
+
+
+@app.route("/register", methods=["GET", "POST"])
+def register():
+    if request.method == "POST":
+        username = request.form["username"]
+        password = request.form["password"]
+        with Session(engine) as db:
+            if db.query(User).filter(User.username == username).first():
+                return "User already exists", 400
+            is_admin = db.query(User).count() == 0
+            user = User(
+                username=username,
+                password_hash=generate_password_hash(password),
+                is_admin=is_admin,
+            )
+            db.add(user)
+            db.commit()
+            session["user_id"] = user.id
+        return redirect(url_for("index"))
+    return render_template("register.html")
+
+
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        username = request.form["username"]
+        password = request.form["password"]
+        with Session(engine) as db:
+            user = db.query(User).filter(User.username == username).first()
+            if not user or not check_password_hash(user.password_hash, password):
+                return "Invalid credentials", 400
+            session["user_id"] = user.id
+        return redirect(url_for("index"))
+    return render_template("login.html")
+
+
+@app.route("/logout")
+def logout():
+    session.clear()
+    return redirect(url_for("index"))
+
+
+@app.route("/admin/users", methods=["GET", "POST"])
+@admin_required
+def manage_users():
+    with Session(engine) as db:
+        if request.method == "POST":
+            action = request.form.get("action")
+            user_id = int(request.form.get("user_id"))
+            user = db.get(User, user_id)
+            if user:
+                if action == "delete":
+                    db.delete(user)
+                    db.commit()
+                elif action == "toggle_admin":
+                    user.is_admin = not user.is_admin
+                    db.commit()
+        users = db.query(User).all()
+    return render_template("admin_users.html", users=users)
 
 
 @app.route("/")

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float, Date
+from sqlalchemy import Column, Integer, String, Float, Date, Boolean
 from .db import Base
 
 
@@ -13,3 +13,12 @@ class VPS(Base):
     renewal_price = Column(Float)
     currency = Column(String, default="USD")
     exchange_rate = Column(Float, default=1.0)
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True)
+    password_hash = Column(String)
+    is_admin = Column(Boolean, default=False)

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Users</title>
+</head>
+<body>
+    <h1>User Management</h1>
+    <table border="1" cellpadding="5" cellspacing="0">
+        <tr><th>ID</th><th>Username</th><th>Admin</th><th>Actions</th></tr>
+        {% for user in users %}
+        <tr>
+            <td>{{ user.id }}</td>
+            <td>{{ user.username }}</td>
+            <td>{{ 'Yes' if user.is_admin else 'No' }}</td>
+            <td>
+                <form method="post" style="display:inline;">
+                    <input type="hidden" name="user_id" value="{{ user.id }}">
+                    <button name="action" value="toggle_admin" type="submit">
+                        {% if user.is_admin %}Revoke Admin{% else %}Make Admin{% endif %}
+                    </button>
+                </form>
+                <form method="post" style="display:inline;" onsubmit="return confirm('Delete user?');">
+                    <input type="hidden" name="user_id" value="{{ user.id }}">
+                    <button name="action" value="delete" type="submit">Delete</button>
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,17 @@
     <title>VPS Value Calculator</title>
 </head>
 <body>
+    {% if current_user %}
+    <p>Logged in as {{ current_user.username }} |
+        <a href="{{ url_for('logout') }}">Logout</a>
+        {% if current_user.is_admin %}
+        | <a href="{{ url_for('manage_users') }}">Manage Users</a>
+        {% endif %}
+    </p>
+    {% else %}
+    <p><a href="{{ url_for('login') }}">Login</a> | <a href="{{ url_for('register') }}">Register</a></p>
+    {% endif %}
+
     <h1>VPS Value Calculator</h1>
     {% if vps_list %}
     <p>Available VPS images:</p>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    <form method="post">
+        <p><input name="username" placeholder="Username"></p>
+        <p><input type="password" name="password" placeholder="Password"></p>
+        <p><button type="submit">Login</button></p>
+    </form>
+</body>
+</html>
+

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Register</title>
+</head>
+<body>
+    <h1>Register</h1>
+    <form method="post">
+        <p><input name="username" placeholder="Username"></p>
+        <p><input type="password" name="password" placeholder="Password"></p>
+        <p><button type="submit">Register</button></p>
+    </form>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add SQLAlchemy `User` model with admin flag
- implement registration, login, and logout
- auto-assign first user as admin and provide admin dashboard to manage users

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688efb63b3d0832a919be4bed73836bd