### PR TITLE
Add CLI-based VPS management with currency conversion

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from functools import wraps
 from sqlalchemy.orm import Session
 from apscheduler.schedulers.background import BackgroundScheduler
-from datetime import date
+from datetime import date, timedelta
 
 from app.db import engine, Base
 from app.models import VPS, User
@@ -62,10 +62,12 @@ def init_sample():
         if db.query(VPS).count() == 0:
             sample = VPS(
                 name="demo",
-                purchase_date=date.today(),
+                transaction_date=date.today(),
+                expiry_date=date.today() + timedelta(days=30),
                 renewal_days=30,
-                price=10.0,
                 renewal_price=10.0,
+                currency="USD",
+                exchange_rate=1.0,
             )
             db.add(sample)
             db.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -7,9 +7,9 @@ class VPS(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, unique=True, index=True)
-    purchase_date = Column(Date)
+    transaction_date = Column(Date)
+    expiry_date = Column(Date)
     renewal_days = Column(Integer)
-    price = Column(Float)
     renewal_price = Column(Float)
     currency = Column(String, default="USD")
     exchange_rate = Column(Float, default=1.0)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import date
 from jinja2 import Environment, FileSystemLoader
 from pathlib import Path
 
@@ -10,13 +10,13 @@ env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
 
 def calculate_remaining(vps):
     today = date.today()
-    cycle_end = vps.purchase_date + timedelta(days=vps.renewal_days)
-    remaining_days = max((cycle_end - today).days, 0)
-    remaining_value = vps.price * remaining_days / vps.renewal_days
+    remaining_days = max((vps.expiry_date - today).days, 0)
+    total_days = max((vps.expiry_date - vps.transaction_date).days, 1)
+    remaining_value = vps.renewal_price * vps.exchange_rate * remaining_days / total_days
     return {
         "remaining_days": remaining_days,
         "remaining_value": round(remaining_value, 2),
-        "cycle_end": cycle_end,
+        "cycle_end": vps.expiry_date,
     }
 
 

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,108 @@
+from datetime import datetime, date, timedelta
+import argparse
+import requests
+from sqlalchemy.orm import Session
+
+from app.db import engine, Base
+from app.models import VPS
+from app.utils import calculate_remaining
+
+Base.metadata.create_all(bind=engine)
+
+RATE_API = "https://open.er-api.com/v6/latest/"
+
+CYCLE_CHOICES = {
+    "1": ("Monthly", 30),
+    "2": ("Quarterly", 90),
+    "3": ("Yearly", 365),
+    "4": ("Three Years", 365 * 3),
+}
+
+def fetch_rate(currency: str) -> float:
+    """Fetch exchange rate for currency to CNY."""
+    try:
+        resp = requests.get(f"{RATE_API}{currency}", timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return float(data.get("rates", {}).get("CNY", 1.0))
+    except Exception:
+        return 1.0
+
+def prompt_date(prompt: str, default: date | None = None) -> date:
+    while True:
+        raw = input(prompt)
+        if not raw and default:
+            return default
+        try:
+            return datetime.strptime(raw, "%Y-%m-%d").date()
+        except ValueError:
+            print("Enter date as YYYY-MM-DD")
+
+def choose_cycle() -> int:
+    print("Choose payment cycle:")
+    for key, (label, _) in CYCLE_CHOICES.items():
+        print(f"{key}. {label}")
+    choice = input("> ").strip()
+    return CYCLE_CHOICES.get(choice, CYCLE_CHOICES["1"])[1]
+
+def add_vps():
+    name = input("VPS name: ").strip()
+    currency = input("Currency (e.g., USD, CNY, EUR): ").strip().upper() or "USD"
+    price = float(input("Renewal price: ").strip())
+    cycle_days = choose_cycle()
+    transaction_date = prompt_date("Transaction date (YYYY-MM-DD, default today): ", date.today())
+    expiry_date = prompt_date("Expiry date (YYYY-MM-DD, blank to auto): ", transaction_date + timedelta(days=cycle_days))
+    rate = fetch_rate(currency)
+    with Session(engine) as db:
+        vps = VPS(
+            name=name,
+            transaction_date=transaction_date,
+            expiry_date=expiry_date,
+            renewal_days=cycle_days,
+            renewal_price=price,
+            currency=currency,
+            exchange_rate=rate,
+        )
+        db.add(vps)
+        db.commit()
+    print("VPS added.")
+
+def list_vps():
+    with Session(engine) as db:
+        vps_list = db.query(VPS).all()
+    if not vps_list:
+        print("No VPS entries found.")
+        return
+    header = f"{'Name':15} {'Currency':8} {'Price':>10} {'Remain(d)':>10} {'Value(CNY)':>12}"
+    print(header)
+    for vps in vps_list:
+        data = calculate_remaining(vps)
+        line = f"{vps.name:15} {vps.currency:8} {vps.renewal_price:10.2f} {data['remaining_days']:10} {data['remaining_value']:12.2f}"
+        print(line)
+
+def interactive_menu():
+    while True:
+        print("\n1. List VPS\n2. Add VPS\n3. Quit")
+        choice = input("> ").strip()
+        if choice == "1":
+            list_vps()
+        elif choice == "2":
+            add_vps()
+        elif choice == "3":
+            break
+        else:
+            print("Invalid choice")
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", nargs="?", choices=["list", "add"])
+    args = parser.parse_args()
+    if args.action == "list":
+        list_vps()
+    elif args.action == "add":
+        add_vps()
+    else:
+        interactive_menu()
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.2
 SQLAlchemy==2.0.23
 APScheduler==3.10.4
+requests==2.31.0

--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -4,8 +4,8 @@
     .text { font: 14px sans-serif; }
   </style>
   <text x="20" y="30" class="title">{{ vps.name }}</text>
-  <text x="20" y="60" class="text">Purchase Date: {{ vps.purchase_date }}</text>
-  <text x="20" y="80" class="text">Renewal Days: {{ vps.renewal_days }}</text>
+  <text x="20" y="60" class="text">Transaction Date: {{ vps.transaction_date }}</text>
+  <text x="20" y="80" class="text">Expiry Date: {{ vps.expiry_date }}</text>
   <text x="20" y="100" class="text">Remaining Days: {{ data.remaining_days }}</text>
-  <text x="20" y="120" class="text">Remaining Value: {{ data.remaining_value }} {{ vps.currency }}</text>
+  <text x="20" y="120" class="text">Remaining Value: {{ data.remaining_value }} CNY</text>
 </svg>


### PR DESCRIPTION
## Summary
- add interactive CLI for configuring and listing VPS entries with real-time exchange rates
- extend VPS model with transaction/expiry dates and currency fields
- compute remaining value using dates and auto-fetched rates

## Testing
- `pip install -r requirements.txt`
- `python -m pytest`
- `python cli.py add` (manual)
- `python cli.py list`


------
https://chatgpt.com/codex/tasks/task_e_688efd699070832ab7dd03eb858d29ed