### PR TITLE
Fix missing expiry_date column migration

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -29,6 +29,19 @@ def _run_migrations():
                         """
                     )
                 )
+        if "expiry_date" not in columns:
+            with engine.begin() as conn:
+                conn.execute(text("ALTER TABLE vps ADD COLUMN expiry_date DATE"))
+                # Infer the expiry date from transaction_date and renewal_days
+                conn.execute(
+                    text(
+                        """
+                        UPDATE vps
+                        SET expiry_date = DATE(transaction_date, '+' || renewal_days || ' day')
+                        WHERE expiry_date IS NULL AND transaction_date IS NOT NULL AND renewal_days IS NOT NULL
+                        """
+                    )
+                )
 
 
 _run_migrations()


### PR DESCRIPTION
## Summary
- add schema migration to create missing `expiry_date` column and backfill values

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python app.py >/tmp/app.log 2>&1 & APP_PID=$!; sleep 5; kill $APP_PID; sleep 1; cat /tmp/app.log`


------
https://chatgpt.com/codex/tasks/task_e_688f004665d4832a960fbc1edf5f5e2f