### PR TITLE
Add dynamic VPS entry form with extended metadata

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -13,6 +13,17 @@ class VPS(Base):
     renewal_price = Column(Float)
     currency = Column(String, default="USD")
     exchange_rate = Column(Float, default=1.0)
+    vendor_name = Column(String)
+    instance_config = Column(String)
+    location = Column(String)
+    purpose = Column(String)
+    traffic_limit = Column(String)
+    payment_method = Column(String)
+    transaction_fee = Column(Float, default=0.0)
+    exchange_rate_source = Column(String, default="system")
+    update_cycle = Column(Integer, default=7)
+    dynamic_svg = Column(Boolean, default=True)
+    status = Column(String, default="active")
 
 
 class User(Base):

--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Add VPS</title>
+    <script src="https://unpkg.com/vue@3"></script>
+</head>
+<body>
+<div id="app">
+    <h1>Add VPS</h1>
+    <form method="post">
+        <div>
+            <label>Name: <input v-model="form.name" name="name" required></label>
+        </div>
+        <div>
+            <label>Transaction Date: <input type="date" v-model="form.transaction_date" name="transaction_date" required></label>
+        </div>
+        <div>
+            <label>Expiry Date: <input type="date" v-model="form.expiry_date" name="expiry_date" required></label>
+        </div>
+        <div>
+            <label>Renewal Days: <input type="number" v-model="form.renewal_days" name="renewal_days" required></label>
+        </div>
+        <div>
+            <label>Renewal Price: <input type="number" step="0.01" v-model="form.renewal_price" name="renewal_price" required></label>
+        </div>
+        <div>
+            <label>Currency: <input v-model="form.currency" name="currency" required></label>
+        </div>
+        <div>
+            <label>Exchange Rate: <input type="number" step="0.0001" v-model="form.exchange_rate" name="exchange_rate" required></label>
+        </div>
+        <div>
+            <label>Vendor Name: <input v-model="form.vendor_name" name="vendor_name"></label>
+        </div>
+        <div>
+            <label>Instance Config: <input v-model="form.instance_config" name="instance_config"></label>
+        </div>
+        <div>
+            <label>Location: <input v-model="form.location" name="location"></label>
+        </div>
+        <div>
+            <label>Purpose: <input v-model="form.purpose" name="purpose"></label>
+        </div>
+        <div>
+            <label>Traffic Limit: <input v-model="form.traffic_limit" name="traffic_limit"></label>
+        </div>
+        <div>
+            <label>Payment Method:
+                <select v-model="form.payment_method" name="payment_method">
+                    <option value="PayPal">PayPal</option>
+                    <option value="Credit Card">Credit Card</option>
+                    <option value="Crypto">Crypto</option>
+                </select>
+            </label>
+        </div>
+        <div>
+            <label>Transaction Fee: <input type="number" step="0.01" v-model="form.transaction_fee" name="transaction_fee"></label>
+        </div>
+        <div>
+            <label>Exchange Rate Source:
+                <select v-model="form.exchange_rate_source" name="exchange_rate_source">
+                    <option value="system">系统自动</option>
+                    <option value="custom">自定义</option>
+                </select>
+            </label>
+        </div>
+        <div>
+            <label>Update Cycle:
+                <select v-model="form.update_cycle" name="update_cycle">
+                    <option value="7">7</option>
+                    <option value="15">15</option>
+                    <option value="30">30</option>
+                </select>
+            </label>
+        </div>
+        <div>
+            <label>Dynamic SVG: <input type="checkbox" v-model="form.dynamic_svg" name="dynamic_svg"></label>
+        </div>
+        <div>
+            <label>Status:
+                <select v-model="form.status" name="status">
+                    <option value="active">Active</option>
+                    <option value="selling">出售中</option>
+                    <option value="sold">已转手</option>
+                </select>
+            </label>
+        </div>
+        <button type="submit">Save</button>
+    </form>
+</div>
+<script>
+const { createApp } = Vue;
+createApp({
+    data() {
+        return {
+            form: {
+                name: '',
+                transaction_date: '',
+                expiry_date: '',
+                renewal_days: 30,
+                renewal_price: 0,
+                currency: 'USD',
+                exchange_rate: 1,
+                vendor_name: '',
+                instance_config: '',
+                location: '',
+                purpose: '',
+                traffic_limit: '',
+                payment_method: 'PayPal',
+                transaction_fee: 0,
+                exchange_rate_source: 'system',
+                update_cycle: 7,
+                dynamic_svg: true,
+                status: 'active'
+            }
+        }
+    }
+}).mount('#app');
+</script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,6 +17,9 @@
     {% endif %}
 
     <h1>VPS Value Calculator</h1>
+    {% if current_user %}
+    <p><a href="{{ url_for('add_vps') }}">Add VPS</a></p>
+    {% endif %}
     {% if vps_list %}
     <p>Available VPS images:</p>
     <ul>


### PR DESCRIPTION
## Summary
- extend VPS model with vendor, config, location, traffic, payment, fee and display options
- add Vue-powered page and `/vps/new` route to input VPS info and generate SVGs
- link form from index and skip SVG generation when dynamic display is disabled

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688f020dd048832a9dd78f2c6e56f4d7