### PR TITLE
fix: add migrations for new VPS columns

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -43,6 +43,25 @@ def _run_migrations():
                     )
                 )
 
+        # Add any new optional columns introduced after initial release
+        optional_columns = {
+            "vendor_name": "TEXT",
+            "instance_config": "TEXT",
+            "location": "TEXT",
+            "purpose": "TEXT",
+            "traffic_limit": "TEXT",
+            "payment_method": "TEXT",
+            "transaction_fee": "FLOAT DEFAULT 0.0",
+            "exchange_rate_source": "TEXT",
+            "update_cycle": "INTEGER DEFAULT 7",
+            "dynamic_svg": "BOOLEAN DEFAULT 1",
+            "status": "TEXT DEFAULT 'active'",
+        }
+        for column, definition in optional_columns.items():
+            if column not in columns:
+                with engine.begin() as conn:
+                    conn.execute(text(f"ALTER TABLE vps ADD COLUMN {column} {definition}"))
+
 
 _run_migrations()
 


### PR DESCRIPTION
## Summary
- ensure legacy databases receive newer VPS fields like vendor_name, transaction_fee, and dynamic_svg

## Testing
- `python -m py_compile app/db.py`
- Created legacy `vps.db`, imported `app.py`, and confirmed new columns and sample data were created

------
https://chatgpt.com/codex/tasks/task_e_688f03b6c778832a8bdc17a9f0b7e039