### PR TITLE
fix: remove tailwind CDN warning

### DIFF
--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>添加 VPS</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" integrity="sha512-wc4x4EwWxvV/1srO2Qd6hw2yYB9H9n1tFoZT3zh0+BTtPlqvGjufH6G+j6/adJzi10BGSAdoo6gWQBa4xZ7Xow==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://unpkg.com/babel-standalone@7/babel.min.js"></script>


### PR DESCRIPTION
## Summary
- avoid production warning by replacing Tailwind CDN script with minified CSS link

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f088cb3f4832a80aa2f1ae5395c9f