### PR TITLE
fix: correct Tailwind CSS integrity hash

### DIFF
--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>添加 VPS</title>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" integrity="sha512-wc4x4EwWxvV/1srO2Qd6hw2yYB9H9n1tFoZT3zh0+BTtPlqvGjufH6G+j6/adJzi10BGSAdoo6gWQBa4xZ7Xow==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" integrity="sha512-wnea99uKIC3TJF7v4eKk4Y+lMz2Mklv18+r4na2Gn1abDRPPOeef95xTzdwGD9e6zXJBteMIhZ1+68QC5byJZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://unpkg.com/babel-standalone@7/babel.min.js"></script>


### PR DESCRIPTION
## Summary
- fix Tailwind CSS CDN integrity hash in add_vps template

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688f09e5b888832aad2c8d076221da73