### PR TITLE
fix: update Babel CDN path

### DIFF
--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" integrity="sha512-wnea99uKIC3TJF7v4eKk4Y+lMz2Mklv18+r4na2Gn1abDRPPOeef95xTzdwGD9e6zXJBteMIhZ1+68QC5byJZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com/babel-standalone@7/babel.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone@7/babel.min.js"></script>
 </head>
 <body class="bg-gray-100">
   <div id="root"></div>


### PR DESCRIPTION
## Summary
- fix 404 by switching to @babel/standalone CDN in add_vps template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f0b0af2f4832a81d49872eb433185