### PR TITLE
Improve VPS gallery with modal SVG preview

### DIFF
--- a/templates/vps.html
+++ b/templates/vps.html
@@ -4,19 +4,24 @@
     <meta charset="UTF-8">
     <title>VPS Gallery</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/cyborg/bootstrap.min.css">
+    <style>
+        body {
+            background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+            min-height: 100vh;
+        }
+    </style>
 </head>
-<body>
+<body class="text-light">
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="{{ url_for('vps_list') }}">VPS Value</a>
-        <div class="d-flex">
+        <div class="d-flex align-items-center">
             {% if current_user %}
             <span class="navbar-text me-3">Hi, {{ current_user.username }}</span>
             <a class="btn btn-outline-light btn-sm me-2" href="{{ url_for('logout') }}">Logout</a>
             {% if current_user.is_admin %}
-            <a class="btn btn-outline-warning btn-sm me-2" href="{{ url_for('manage_users') }}">Manage Users</a>
+            <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('manage_users') }}">Manage Users</a>
             {% endif %}
-            <a class="btn btn-success btn-sm" href="{{ url_for('add_vps') }}">Add VPS</a>
             {% else %}
             <a class="btn btn-outline-light btn-sm me-2" href="{{ url_for('login') }}">Login</a>
             <a class="btn btn-outline-light btn-sm" href="{{ url_for('register') }}">Register</a>
@@ -26,17 +31,18 @@
 </nav>
 
 <div class="container mt-4">
-    <h1 class="mb-4">VPS Gallery</h1>
+    <h1 class="mb-4 text-center">VPS Gallery</h1>
     {% if vps_list %}
-    <div class="row">
+    <div class="row g-4">
         {% for vps in vps_list %}
-        <div class="col-md-4 mb-4">
-            <div class="card bg-secondary text-white h-100">
-                <div class="card-body">
+        <div class="col-12 col-sm-6 col-md-4">
+            <div class="card bg-secondary text-white h-100 shadow-lg rounded-3">
+                <div class="card-body d-flex flex-column align-items-center text-center">
                     <h5 class="card-title">{{ vps.name }}</h5>
                     {% if vps.vendor_name %}<h6 class="card-subtitle mb-2 text-muted">{{ vps.vendor_name }}</h6>{% endif %}
                     {% if vps.expiry_date %}<p class="card-text">Expires: {{ vps.expiry_date }}</p>{% endif %}
-                    <a href="{{ url_for('get_vps_image', name=vps.name) }}" class="btn btn-outline-light" target="_blank">View SVG</a>
+                    <img src="{{ url_for('get_vps_image', name=vps.name) }}" alt="{{ vps.name }} preview" class="img-fluid mt-2 bg-light rounded p-2" style="max-height:150px;">
+                    <button class="btn btn-success mt-3" data-bs-toggle="modal" data-bs-target="#svgModal" data-svg="{{ url_for('get_vps_image', name=vps.name) }}" data-name="{{ vps.name }}" data-vendor="{{ vps.vendor_name }}" data-expiry="{{ vps.expiry_date }}">View SVG</button>
                 </div>
             </div>
         </div>
@@ -46,5 +52,49 @@
     <p>No VPS entries found.</p>
     {% endif %}
 </div>
+
+<a href="{{ url_for('add_vps') }}" class="btn btn-success rounded-circle position-fixed" style="width:60px;height:60px;font-size:30px;bottom:20px;right:20px;line-height:44px;">+</a>
+
+<div class="modal fade" id="svgModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered modal-xl">
+    <div class="modal-content bg-dark text-white">
+      <div class="modal-header">
+        <h5 class="modal-title" id="svgModalLabel"></h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body text-center">
+        <img id="svgImage" src="" alt="SVG Preview" class="img-fluid">
+        <p class="mt-3" id="svgInfo"></p>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" id="copyLinkBtn">Copy Link</button>
+        <a href="#" id="downloadLink" class="btn btn-primary" download>Download</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  const svgModal = document.getElementById('svgModal');
+  svgModal.addEventListener('show.bs.modal', event => {
+    const button = event.relatedTarget;
+    const svgUrl = button.getAttribute('data-svg');
+    const name = button.getAttribute('data-name');
+    const vendor = button.getAttribute('data-vendor') || '';
+    const expiry = button.getAttribute('data-expiry') || '';
+    const modalTitle = svgModal.querySelector('.modal-title');
+    const svgImage = document.getElementById('svgImage');
+    const info = document.getElementById('svgInfo');
+    const downloadLink = document.getElementById('downloadLink');
+    modalTitle.textContent = name;
+    svgImage.src = svgUrl;
+    info.textContent = `${vendor}${expiry ? ' - Expires: ' + expiry : ''}`;
+    downloadLink.href = svgUrl;
+    document.getElementById('copyLinkBtn').onclick = () => {
+      navigator.clipboard.writeText(svgUrl);
+    };
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance gallery cards with preview images, responsive grid, and dark gradient background
- add modal to view SVGs with copy and download actions
- introduce floating "Add VPS" button and toned down admin controls

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f0e421568832ab1038913167e4011