### PR TITLE
refactor: improve VPS form usability

### DIFF
--- a/app.py
+++ b/app.py
@@ -168,7 +168,7 @@ def add_vps():
                 vendor_name=form.get("vendor_name"),
                 instance_config=form.get("instance_config"),
                 location=form.get("location"),
-                purpose=form.get("purpose"),
+                description=form.get("description"),
                 traffic_limit=form.get("traffic_limit"),
                 payment_method=form.get("payment_method"),
                 transaction_fee=float(form.get("transaction_fee") or 0.0),
@@ -212,7 +212,7 @@ def edit_vps(vps_id: int):
             vps.vendor_name = form.get("vendor_name")
             vps.instance_config = form.get("instance_config")
             vps.location = form.get("location")
-            vps.purpose = form.get("purpose")
+            vps.description = form.get("description")
             vps.traffic_limit = form.get("traffic_limit")
             vps.payment_method = form.get("payment_method")
             vps.transaction_fee = float(form.get("transaction_fee") or 0.0)
@@ -235,7 +235,7 @@ def edit_vps(vps_id: int):
             "vendor_name": vps.vendor_name,
             "instance_config": vps.instance_config,
             "location": vps.location,
-            "purpose": vps.purpose,
+            "description": vps.description,
             "traffic_limit": vps.traffic_limit,
             "payment_method": vps.payment_method,
             "transaction_fee": vps.transaction_fee,

--- a/app/db.py
+++ b/app/db.py
@@ -48,7 +48,7 @@ def _run_migrations():
             "vendor_name": "TEXT",
             "instance_config": "TEXT",
             "location": "TEXT",
-            "purpose": "TEXT",
+            "description": "TEXT",
             "traffic_limit": "TEXT",
             "payment_method": "TEXT",
             "transaction_fee": "FLOAT DEFAULT 0.0",

--- a/app/models.py
+++ b/app/models.py
@@ -16,7 +16,7 @@ class VPS(Base):
     vendor_name = Column(String)
     instance_config = Column(String)
     location = Column(String)
-    purpose = Column(String)
+    description = Column(String)
     traffic_limit = Column(String)
     payment_method = Column(String)
     transaction_fee = Column(Float, default=0.0)

--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -42,14 +42,14 @@
         name: '',
         transaction_date: today,
         expiry_date: '',
-        renewal_days: '',
+        renewal_days: '30',
         renewal_price: '',
         currency: 'USD',
         exchange_rate: '',
         vendor_name: '',
         instance_config: '',
         location: '',
-        purpose: '',
+        description: '',
         traffic_limit: '',
         payment_method: 'PayPal',
         transaction_fee: '0',
@@ -103,8 +103,15 @@
                   <input name="vendor_name" value={form.vendor_name} onChange={handleChange} placeholder="请输入厂商名称" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
                 </div>
                 <div className="flex flex-col mt-4">
-                  <label className="mb-1 text-cyan-200">用途</label>
-                  <input name="purpose" value={form.purpose} onChange={handleChange} placeholder="例如 科学上网/建站" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
+                  <label className="mb-1 text-cyan-200">描述</label>
+                  <textarea
+                    name="description"
+                    value={form.description}
+                    onChange={handleChange}
+                    placeholder="如 科学上网 / 建站 / 测试使用"
+                    className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none resize-none"
+                    rows={2}
+                  />
                 </div>
                 <div className="flex flex-col mt-4">
                   <label className="mb-1 text-cyan-200">VPS 状态</label>
@@ -118,12 +125,18 @@
               <fieldset className="border-b border-cyan-500 pb-4 mb-4">
                 <legend className="text-lg mb-2 text-cyan-300">续费信息</legend>
                 <div className="flex flex-col">
-                  <label className="mb-1 text-cyan-200">续费周期（天）</label>
-                  <input type="number" name="renewal_days" value={form.renewal_days} onChange={handleChange} placeholder="例如 30" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
+                  <label className="mb-1 text-cyan-200">续费周期</label>
+                  <select name="renewal_days" value={form.renewal_days} onChange={handleChange} className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white focus:ring-2 focus:ring-cyan-400">
+                    <option value="30">每月</option>
+                    <option value="90">每季度</option>
+                    <option value="365">每年</option>
+                    <option value="1095">三年</option>
+                    <option value="0">一次性</option>
+                  </select>
                 </div>
                 <div className="flex flex-col mt-4">
                   <label className="mb-1 text-cyan-200">续费金额</label>
-                  <input type="number" step="0.01" name="renewal_price" value={form.renewal_price} onChange={handleChange} placeholder="例如 5.99" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
+                  <input type="number" step="0.01" name="renewal_price" value={form.renewal_price} onChange={handleChange} placeholder="如 5.99" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
                 </div>
                 <div className="flex flex-col mt-4">
                   <label className="mb-1 text-cyan-200">币种</label>
@@ -135,10 +148,9 @@
                     <option value="HKD">港币（HKD）</option>
                   </select>
                 </div>
-                <div className="flex flex-col mt-4 relative">
-                  <label className="mb-1 text-cyan-200">实时汇率 (→ CNY)</label>
-                  <input type="number" step="0.0001" name="exchange_rate" value={form.exchange_rate} onChange={handleChange} readOnly={form.exchange_rate_source === 'system'} className={`w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none ${form.exchange_rate_source === 'system' ? 'opacity-75' : ''}`} />
-                  {form.exchange_rate_source === 'system' && <span className="absolute right-2 top-8">🔄</span>}
+                <div className="flex flex-col mt-4">
+                  <label className="mb-1 text-cyan-200">支付手续费（USD）</label>
+                  <input type="number" step="0.01" name="transaction_fee" value={form.transaction_fee} onChange={handleChange} placeholder="如 0.5，单位 USD" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
                 </div>
                 <div className="flex flex-col mt-4">
                   <label className="mb-1 text-cyan-200">支付方式</label>
@@ -152,15 +164,19 @@
                   </select>
                 </div>
                 <div className="flex flex-col mt-4">
-                  <label className="mb-1 text-cyan-200">支付手续费（USD）</label>
-                  <input type="number" step="0.01" name="transaction_fee" value={form.transaction_fee} onChange={handleChange} placeholder="如：0.5，单位 USD" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
-                </div>
-                <div className="flex flex-col mt-4">
-                  <label className="mb-1 text-cyan-200">汇率来源</label>
+                  <div className="flex items-center gap-2">
+                    <label className="mb-1 text-cyan-200">汇率来源</label>
+                    <span className="text-gray-400 cursor-help" title="系统自动将通过汇率 API 获取最新汇率">❓</span>
+                  </div>
                   <select name="exchange_rate_source" value={form.exchange_rate_source} onChange={handleChange} className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white focus:ring-2 focus:ring-cyan-400">
                     <option value="system">系统自动</option>
                     <option value="custom">自定义</option>
                   </select>
+                </div>
+                <div className="flex flex-col mt-4 relative">
+                  <label className="mb-1 text-cyan-200">实时汇率 (→ CNY)</label>
+                  <input type="number" step="0.0001" name="exchange_rate" value={form.exchange_rate} onChange={handleChange} readOnly={form.exchange_rate_source === 'system'} className={`w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none ${form.exchange_rate_source === 'system' ? 'opacity-75' : ''}`} />
+                  {form.exchange_rate_source === 'system' && <span className="absolute right-2 top-8">🔄</span>}
                 </div>
               </fieldset>
 
@@ -184,25 +200,25 @@
                 </div>
                 <div className="flex flex-col mt-4">
                   <label className="mb-1 text-cyan-200">所在机房</label>
-                  <input name="location" value={form.location} onChange={handleChange} placeholder="例如：洛杉矶 / 香港" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
+                  <input name="location" value={form.location} onChange={handleChange} placeholder="如 洛杉矶 / 香港" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
                 </div>
                 <div className="flex flex-col mt-4">
                   <label className="mb-1 text-cyan-200">流量限制（月）</label>
-                  <input name="traffic_limit" value={form.traffic_limit} onChange={handleChange} placeholder="例如：3TB / 无限" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
+                  <input name="traffic_limit" value={form.traffic_limit} onChange={handleChange} placeholder="如 3TB / 无限" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
                 </div>
               </fieldset>
 
               <fieldset className="border-b border-cyan-500 pb-4 mb-4">
                 <legend className="text-lg mb-2 text-cyan-300">设置项</legend>
-                <div className="flex items-center">
-                  <label className="mr-2 text-cyan-200">动态 SVG</label>
+                <div className="flex items-center gap-2">
                   <input type="checkbox" name="dynamic_svg" checked={form.dynamic_svg} onChange={handleChange} className="h-5 w-5" />
+                  <label className="text-cyan-200">启用动态 SVG（每天自动更新剩余价值）</label>
                 </div>
               </fieldset>
 
               <input type="hidden" name="update_cycle" value={form.update_cycle} />
 
-              <button type="submit" className="w-full mt-6 bg-green-500 hover:bg-green-400 text-black font-bold py-2 px-4 rounded-full transition shadow-lg hover:shadow-green-300">保存</button>
+              <button type="submit" className="w-full mt-6 bg-green-500 hover:bg-green-400 text-black font-bold py-2 px-4 rounded-full transition shadow-lg hover:shadow-green-300">💾 保存</button>
             </form>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace vague "用途" field with clearer "描述" textarea and monthly cycle default
- add renewal-cycle dropdown and tooltip for exchange rate source
- polish dynamic SVG toggle and save button

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f1b894670832a8e67623a13b494ef