### PR TITLE
Simplify card interaction and add SVG view page

### DIFF
--- a/app.py
+++ b/app.py
@@ -270,6 +270,17 @@ def vps_list():
     return render_template("vps.html", vps_list=vps_list)
 
 
+@app.route("/vps/<string:name>")
+def view_vps(name: str):
+    with Session(engine) as db:
+        vps = db.query(VPS).filter(VPS.name == name).first()
+        if not vps or not vps.dynamic_svg:
+            abort(404)
+    svg_url = url_for("get_vps_image", name=name)
+    svg_abs_url = url_for("get_vps_image", name=name, _external=True)
+    return render_template("view_svg.html", name=name, svg_url=svg_url, svg_abs_url=svg_abs_url)
+
+
 @app.route("/vps/<string:name>.svg")
 def get_vps_image(name: str):
     with Session(engine) as db:

--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -13,7 +13,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-start;
   width: 360px;
   height: 460px;
   padding: 1.5rem;
@@ -22,6 +22,8 @@
   box-shadow: 0 4px 12px rgba(0, 255, 170, 0.08), 0 0 0 1px rgba(0, 255, 170, 0.15);
   border: 1px solid rgba(0, 255, 170, 0.2);
   transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  color: inherit;
+  text-decoration: none;
 }
 
 .vps-card:hover {
@@ -85,42 +87,4 @@
   box-shadow: inset 0 0 10px #00ff55;
   border: 1px solid rgba(0, 255, 170, 0.1);
   min-height: 160px;
-}
-
-/* 底部按钮区域 */
-.vps-card .card-footer {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 1.5rem;
-}
-
-/* 按钮样式 */
-.vps-card button,
-.vps-card .btn {
-  flex: 1;
-  margin: 0 0.5rem;
-  padding: 0.6rem 1rem;
-  font-weight: bold;
-  font-size: 0.95rem;
-  border-radius: 12px;
-  border: none;
-  cursor: pointer;
-  transition: all 0.2s ease-in-out;
-}
-
-/* SVG 按钮 */
-.vps-card .btn-svg {
-  background: linear-gradient(to right, #34e89e, #0f3443);
-  color: white;
-}
-
-/* Markdown 复制按钮 */
-.vps-card .btn-md {
-  background: linear-gradient(to right, #3a7bd5, #00d2ff);
-  color: white;
-}
-
-.vps-card .btn:hover {
-  transform: translateY(-2px);
-  opacity: 0.9;
 }

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ name }} - SVG 展示</title>
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/crt.css') }}">
+</head>
+<body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono flex flex-col items-center justify-center p-4">
+    <div class="w-full max-w-4xl">
+        <div class="crt p-4 rounded overflow-auto">
+            <img src="{{ svg_url }}" alt="{{ name }}" class="mx-auto">
+        </div>
+        <div class="text-center mt-4">
+            <button id="copyLinkBtn" class="border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-4 py-2 rounded transition">复制链接</button>
+        </div>
+    </div>
+    <script>
+        document.getElementById('copyLinkBtn').addEventListener('click', function () {
+            navigator.clipboard.writeText('{{ svg_abs_url }}').then(() => {
+                alert('链接已复制');
+            }).catch(() => {
+                alert('复制失败，请手动复制。');
+            });
+        });
+    </script>
+</body>
+</html>
+

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -35,7 +35,7 @@
     {% if vps_list %}
     <div class="card-container">
         {% for vps in vps_list %}
-        <div class="vps-card relative shadow-2xl bg-[#1a1a1a] border border-cyan-400 transition transform hover:scale-105 hover:shadow-cyan-400/40 duration-300">
+        <a class="vps-card relative shadow-2xl bg-[#1a1a1a] border border-cyan-400 transition transform hover:scale-105 hover:shadow-cyan-400/40 duration-300" href="{{ url_for('view_vps', name=vps.name) }}">
             {% if vps.status %}
             {% if vps.status == 'active' %}
             <span class="status-badge bg-green-500">在使用</span>
@@ -59,78 +59,12 @@
                     {% if vps.transaction_fee %}<span class="text-gray-400">手续费</span><span>{{ vps.transaction_fee }}</span>{% endif %}
                 </div>
             </div>
-            <div class="flex gap-2">
-                <button class="flex-1 bg-green-500 hover:bg-green-400 text-black font-bold py-2 px-4 rounded-full shadow-lg hover:shadow-green-400 transition"
-                        data-bs-toggle="modal" data-bs-target="#svgModal"
-                        data-svg="{{ url_for('get_vps_image', name=vps.name) }}"
-                        data-name="{{ vps.name }}" data-vendor="{{ vps.vendor_name }}" data-expiry="{{ vps.expiry_date }}">
-                    查看 SVG
-                </button>
-                <button class="flex-1 bg-blue-500 hover:bg-blue-400 text-black font-bold py-2 px-4 rounded-full shadow-lg hover:shadow-blue-400 transition"
-                        onclick="copyToClipboard('![{{ vps.name }}]({{ url_for('get_vps_image', name=vps.name, _external=True) }})')">
-                    复制 Markdown
-                </button>
-            </div>
-        </div>
+        </a>
         {% endfor %}
     </div>
     {% else %}
     <p class="text-center">暂无 VPS 条目。</p>
     {% endif %}
 </div>
-
-
-
-<div class="modal fade" id="svgModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-xl">
-    <div class="modal-content bg-[#1a1a1a] text-white border border-cyan-400">
-      <div class="modal-header">
-        <h5 class="modal-title" id="svgModalLabel"></h5>
-        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <div id="svgDisplay" class="crt p-4 rounded overflow-auto"></div>
-        <p class="mt-3 text-center" id="svgInfo"></p>
-      </div>
-      <div class="modal-footer">
-        <button class="btn btn-secondary" id="copyLinkBtn">复制链接</button>
-        <a href="#" id="downloadLink" class="btn btn-primary" download>下载</a>
-      </div>
-    </div>
-  </div>
-</div>
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-<script>
-  const svgModal = document.getElementById('svgModal');
-  svgModal.addEventListener('show.bs.modal', event => {
-    const button = event.relatedTarget;
-    const svgUrl = button.getAttribute('data-svg');
-    const name = button.getAttribute('data-name');
-    const vendor = button.getAttribute('data-vendor') || '';
-    const expiry = button.getAttribute('data-expiry') || '';
-    const modalTitle = svgModal.querySelector('.modal-title');
-    const svgDisplay = document.getElementById('svgDisplay');
-    const info = document.getElementById('svgInfo');
-    const downloadLink = document.getElementById('downloadLink');
-    modalTitle.textContent = name;
-    fetch(svgUrl).then(res => res.text()).then(svg => {
-      svgDisplay.innerHTML = svg;
-    });
-    info.textContent = vendor + (expiry ? ' - 到期时间: ' + expiry : '');
-    downloadLink.href = svgUrl;
-    document.getElementById('copyLinkBtn').onclick = () => {
-      copyToClipboard(svgUrl);
-    };
-  });
-
-  function copyToClipboard(content) {
-    navigator.clipboard.writeText(content).then(() => {
-      alert("\u590d\u5236\u6210\u529f\uff01");
-    }).catch(() => {
-      alert("\u590d\u5236\u5931\u8d25\uff0c\u8bf7\u624b\u52a8\u590d\u5236\u3002");
-    });
-  }
-</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make VPS cards link directly to SVG view
- add standalone SVG display page with copy link button
- clean up card styles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f2544cfa0832a9a58f6b65ee4d4d2