### PR TITLE
Add modal SVG preview and smarter VPS cards

### DIFF
--- a/app.py
+++ b/app.py
@@ -170,6 +170,7 @@ def add_vps():
                 location=form.get("location"),
                 description=form.get("description"),
                 traffic_limit=form.get("traffic_limit"),
+                ip_address=form.get("ip_address"),
                 payment_method=form.get("payment_method"),
                 transaction_fee=float(form.get("transaction_fee") or 0.0),
                 exchange_rate_source=form.get("exchange_rate_source"),
@@ -214,6 +215,7 @@ def edit_vps(vps_id: int):
             vps.location = form.get("location")
             vps.description = form.get("description")
             vps.traffic_limit = form.get("traffic_limit")
+            vps.ip_address = form.get("ip_address")
             vps.payment_method = form.get("payment_method")
             vps.transaction_fee = float(form.get("transaction_fee") or 0.0)
             vps.exchange_rate_source = form.get("exchange_rate_source")
@@ -237,6 +239,7 @@ def edit_vps(vps_id: int):
             "location": vps.location,
             "description": vps.description,
             "traffic_limit": vps.traffic_limit,
+            "ip_address": vps.ip_address,
             "payment_method": vps.payment_method,
             "transaction_fee": vps.transaction_fee,
             "exchange_rate_source": vps.exchange_rate_source,
@@ -267,7 +270,8 @@ def index():
 def vps_list():
     with Session(engine) as db:
         vps_list = db.query(VPS).all()
-    return render_template("vps.html", vps_list=vps_list)
+        vps_data = [(vps, calculate_remaining(vps)) for vps in vps_list]
+    return render_template("vps.html", vps_data=vps_data)
 
 
 @app.route("/vps/<string:name>")

--- a/app/db.py
+++ b/app/db.py
@@ -50,6 +50,7 @@ def _run_migrations():
             "location": "TEXT",
             "description": "TEXT",
             "traffic_limit": "TEXT",
+            "ip_address": "TEXT",
             "payment_method": "TEXT",
             "transaction_fee": "FLOAT DEFAULT 0.0",
             "exchange_rate_source": "TEXT",

--- a/app/models.py
+++ b/app/models.py
@@ -18,6 +18,7 @@ class VPS(Base):
     location = Column(String)
     description = Column(String)
     traffic_limit = Column(String)
+    ip_address = Column(String)
     payment_method = Column(String)
     transaction_fee = Column(Float, default=0.0)
     exchange_rate_source = Column(String, default="system")

--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -13,9 +13,10 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
+  justify-content: space-between;
   width: 360px;
-  height: 460px;
+  height: auto;
+  min-height: 520px;
   padding: 1.5rem;
   background: linear-gradient(145deg, #1f1f1f, #151515);
   border-radius: 16px;
@@ -87,4 +88,26 @@
   box-shadow: inset 0 0 10px #00ff55;
   border: 1px solid rgba(0, 255, 170, 0.1);
   min-height: 160px;
+}
+
+/* Modal for SVG preview */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.85);
+  display: none;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #000;
+  border: 1px solid #0f0;
+  padding: 2rem;
+  text-align: center;
+  border-radius: 10px;
 }

--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -1,0 +1,7 @@
+input[type="date"] {
+  background-color: #000;
+  color: #0f0;
+  border: 1px solid #0f0;
+  padding: 0.5rem;
+  border-radius: 6px;
+}

--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -8,6 +8,7 @@
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://unpkg.com/@babel/standalone@7/babel.min.js"></script>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/forms.css') }}">
 </head>
 <body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono">
   <nav class="flex justify-between items-center px-6 py-4 bg-black/80 backdrop-blur shadow-lg border-b border-cyan-400">
@@ -56,7 +57,8 @@
         exchange_rate_source: 'system',
         dynamic_svg: true,
         status: 'active',
-        update_cycle: 1
+        update_cycle: 1,
+        ip_address: ''
       };
       const [form, setForm] = useState({ ...defaultData, ...(window.initialData || {}) });
       const isEdit = Boolean(window.initialData);
@@ -77,6 +79,16 @@
           fetchRate();
         }
       }, [form.currency, form.exchange_rate_source]);
+
+      useEffect(() => {
+        const map = { '30': 1, '90': 3, '365': 12, '1095': 36 };
+        if (form.transaction_date && map[form.renewal_days]) {
+          const start = new Date(form.transaction_date);
+          const end = new Date(start);
+          end.setMonth(start.getMonth() + map[form.renewal_days]);
+          setForm(f => ({ ...f, expiry_date: end.toISOString().split('T')[0] }));
+        }
+      }, [form.transaction_date, form.renewal_days]);
 
       const handleChange = (e) => {
         const { name, value, type, checked } = e.target;
@@ -205,6 +217,10 @@
                 <div className="flex flex-col mt-4">
                   <label className="mb-1 text-cyan-200">流量限制（月）</label>
                   <input name="traffic_limit" value={form.traffic_limit} onChange={handleChange} placeholder="如 3TB / 无限" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
+                </div>
+                <div className="flex flex-col mt-4">
+                  <label className="mb-1 text-cyan-200">IP 地址</label>
+                  <input name="ip_address" value={form.ip_address} onChange={handleChange} placeholder="如 1.2.3.4" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
                 </div>
               </fieldset>
 

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -32,10 +32,10 @@
 
 <div class="container mx-auto px-4 py-8">
     <h1 class="text-center text-4xl font-bold text-cyan-300 mb-8">VPS 列表</h1>
-    {% if vps_list %}
+    {% if vps_data %}
     <div class="card-container">
-        {% for vps in vps_list %}
-        <a class="vps-card relative shadow-2xl bg-[#1a1a1a] border border-cyan-400 transition transform hover:scale-105 hover:shadow-cyan-400/40 duration-300" href="{{ url_for('view_vps', name=vps.name) }}">
+        {% for vps, data in vps_data %}
+        <div class="vps-card relative shadow-2xl bg-[#1a1a1a] border border-cyan-400 transition transform hover:scale-105 hover:shadow-cyan-400/40 duration-300 cursor-pointer" data-svg="{{ url_for('get_vps_image', name=vps.name) }}" data-link="{{ url_for('get_vps_image', name=vps.name, _external=True) }}">
             {% if vps.status %}
             {% if vps.status == 'active' %}
             <span class="status-badge bg-green-500">在使用</span>
@@ -49,22 +49,49 @@
             {% if vps.vendor_name %}<h3 class="text-sm text-gray-400 text-center mb-2">{{ vps.vendor_name }}</h3>{% endif %}
             <div class="crt p-4 rounded overflow-x-auto min-h-[160px] mb-4">
                 <div class="grid grid-cols-2 gap-x-4 text-sm">
+                    {% if vps.vendor_name %}<span class="text-gray-400">商家</span><span>{{ vps.vendor_name }}</span>{% endif %}
                     <span class="text-gray-400">交易时间</span><span>{{ vps.transaction_date }}</span>
                     {% if vps.expiry_date %}<span class="text-gray-400">到期时间</span><span>{{ vps.expiry_date }}</span>{% endif %}
                     {% if vps.instance_config %}<span class="text-gray-400">配置</span><span>{{ vps.instance_config }}</span>{% endif %}
-                    {% if vps.location %}<span class="text-gray-400">地区</span><span>{{ vps.location }}</span>{% endif %}
                     {% if vps.traffic_limit %}<span class="text-gray-400">流量</span><span>{{ vps.traffic_limit }}</span>{% endif %}
-                    {% if vps.renewal_price %}<span class="text-gray-400">续费</span><span>{{ vps.renewal_price }} {{ vps.currency }}</span>{% endif %}
-                    {% if vps.payment_method %}<span class="text-gray-400">支付方式</span><span>{{ vps.payment_method }}</span>{% endif %}
-                    {% if vps.transaction_fee %}<span class="text-gray-400">手续费</span><span>{{ vps.transaction_fee }}</span>{% endif %}
+                    {% if vps.ip_address %}{% set parts = vps.ip_address.split('.') %}{% set masked = parts[:-1]|join('.') ~ '.***' %}<span class="text-gray-400">IP</span><span>{{ masked }}</span>{% endif %}
+                    <span class="text-gray-400">剩余天数</span><span class="text-green-400 font-bold">{{ data.remaining_days }}</span>
+                    <span class="text-gray-400">剩余价值</span><span class="text-green-400 font-bold">{{ data.remaining_value }} CNY</span>
                 </div>
             </div>
-        </a>
+        </div>
         {% endfor %}
     </div>
     {% else %}
     <p class="text-center">暂无 VPS 条目。</p>
     {% endif %}
 </div>
+
+<div id="svgModal" class="modal">
+  <div class="modal-content">
+    <button id="closeModal" class="mb-4 border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-3 py-1 rounded">返回列表</button>
+    <img id="svgImage" src="" alt="SVG 展示图" class="max-w-full h-auto mb-4" />
+    <button id="copyLink" class="border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-3 py-1 rounded">复制链接</button>
+  </div>
+</div>
+
+<script>
+  document.querySelectorAll('.vps-card').forEach(card => {
+    card.addEventListener('click', () => {
+      const svgUrl = card.dataset.svg;
+      const linkUrl = card.dataset.link;
+      document.getElementById('svgImage').src = svgUrl;
+      document.getElementById('copyLink').dataset.link = linkUrl;
+      document.getElementById('svgModal').style.display = 'flex';
+    });
+  });
+  document.getElementById('closeModal').addEventListener('click', () => {
+    document.getElementById('svgModal').style.display = 'none';
+  });
+  document.getElementById('copyLink').addEventListener('click', () => {
+    const link = document.getElementById('copyLink').dataset.link;
+    navigator.clipboard.writeText(link).then(() => alert('链接已复制')).catch(() => alert('复制失败，请手动复制'));
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Render VPS cards with uniform height and a modal SVG preview complete with copyable links and remaining value stats.
- Extend VPS records with `ip_address` and auto-calculate expiry dates based on billing cycle selections.
- Style date inputs for a neon console look.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f281b4670832aa91930270d77fcfd