### PR TITLE
Optimize VPS cards and SVG page interactions

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ from datetime import date, timedelta
 
 from app.db import engine, Base
 from app.models import VPS, User
-from app.utils import calculate_remaining, generate_svg
+from app.utils import calculate_remaining, generate_svg, parse_instance_config
 
 app = Flask(__name__)
 app.secret_key = "change-me"
@@ -273,7 +273,11 @@ def index():
 def vps_list():
     with Session(engine) as db:
         vps_list = db.query(VPS).all()
-        vps_data = [(vps, calculate_remaining(vps)) for vps in vps_list]
+        vps_data = []
+        for vps in vps_list:
+            data = calculate_remaining(vps)
+            specs = parse_instance_config(vps.instance_config)
+            vps_data.append((vps, data, specs))
     return render_template("vps.html", vps_data=vps_data)
 
 

--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -13,31 +13,30 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   width: 360px;
-  height: 620px;
-  overflow-y: auto;
-  padding: 1.5rem;
+  height: 520px;
+  padding: 1rem;
   background: linear-gradient(145deg, #1f1f1f, #151515);
-  border-radius: 16px;
-  box-shadow: 0 4px 12px rgba(0, 255, 170, 0.08), 0 0 0 1px rgba(0, 255, 170, 0.15);
-  border: 1px solid rgba(0, 255, 170, 0.2);
-  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-  color: inherit;
-  text-decoration: none;
+  border-radius: 12px;
+  box-shadow: 0 0 10px #00ff66;
+  border: 1px solid rgba(0, 255, 102, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  font-family: 'Courier New', monospace;
+  color: #00ff66;
+  cursor: pointer;
 }
 
 .vps-card:hover {
-  transform: translateY(-6px);
-  box-shadow: 0 8px 20px rgba(0, 255, 170, 0.2), 0 0 0 1px rgba(0, 255, 170, 0.3);
+  transform: translateY(-5px);
+  box-shadow: 0 0 16px #00ff66;
 }
 
-/* 顶部状态角标 */
+/* 状态角标 */
 .status-badge {
   position: absolute;
-  top: 0.8rem;
-  left: 0.8rem;
-  padding: 0.3rem 0.6rem;
+  top: 0.5rem;
+  left: 0.5rem;
+  padding: 0.2rem 0.5rem;
   font-size: 0.7rem;
   font-weight: bold;
   background-color: #00ffae;
@@ -48,45 +47,24 @@
   z-index: 10;
 }
 
-/* 状态颜色分类 */
-.status-badge.active {
-  background-color: #00ffae;
-}
-.status-badge.transferred {
-  background-color: #ffa500;
-}
-.status-badge.disabled {
-  background-color: #ff4d4d;
-}
-
-/* 卡片标题 */
-.vps-card h3 {
+/* 标题 */
+.vps-title {
+  font-size: 1.2rem;
+  text-align: center;
   color: #00eaff;
-  text-align: center;
-  font-size: 1.4rem;
-  margin-bottom: 0.8rem;
-  letter-spacing: 1px;
 }
 
-/* 子标题/备注 */
-.vps-card .subtitle {
-  text-align: center;
-  color: #999;
-  font-size: 0.9rem;
-  margin-bottom: 1.2rem;
+.vps-content {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }
 
-/* 内容主体：类似 CRT 风格文本框 */
-.vps-card .card-body {
-  background: radial-gradient(circle at top left, #000000 20%, #0f0f0f 100%);
-  border-radius: 10px;
-  padding: 1rem;
-  color: #00ff55;
-  font-family: 'Courier New', Courier, monospace;
-  font-size: 0.95rem;
-  line-height: 1.5;
-  box-shadow: inset 0 0 10px #00ff55;
-  border: 1px solid rgba(0, 255, 170, 0.1);
-  min-height: 160px;
+.vps-row {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
+  border-bottom: 1px solid rgba(0, 255, 102, 0.2);
+  padding-bottom: 0.25rem;
 }
-

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -34,14 +34,13 @@
         </div>
         <div class="flex gap-4 mt-4">
             <a href="{{ url_for('vps_list') }}" class="border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-4 py-2 rounded transition">返回列表</a>
-            <button id="copyLinkBtn" class="border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-4 py-2 rounded transition" data-link="{{ svg_abs_url }}">复制链接</button>
+            <button id="copyLinkBtn" class="border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-4 py-2 rounded transition">复制链接</button>
             <a href="{{ url_for('edit_vps', vps_id=vps_id) }}" class="border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-4 py-2 rounded transition">编辑此项</a>
         </div>
     </div>
     <script>
         document.getElementById('copyLinkBtn').addEventListener('click', function () {
-            const link = this.dataset.link;
-            navigator.clipboard.writeText(link).then(() => {
+            navigator.clipboard.writeText(window.location.href).then(() => {
                 alert('链接已复制');
             }).catch(() => {
                 alert('复制失败，请手动复制。');

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -34,8 +34,8 @@
     <h1 class="text-center text-4xl font-bold text-cyan-300 mb-8">VPS 列表</h1>
     {% if vps_data %}
     <div class="card-container">
-        {% for vps, data in vps_data %}
-        <a href="{{ url_for('view_vps', name=vps.name) }}" class="vps-card relative shadow-2xl bg-[#1a1a1a] border border-cyan-400 transition transform hover:scale-105 hover:shadow-cyan-400/40 duration-300 block">
+        {% for vps, data, specs in vps_data %}
+        <div class="vps-card relative" data-href="{{ url_for('view_vps', name=vps.name) }}">
             {% if vps.status %}
             {% if vps.status == 'active' %}
             <span class="status-badge bg-green-500">在使用</span>
@@ -45,34 +45,35 @@
             <span class="status-badge bg-gray-500">已停用</span>
             {% endif %}
             {% endif %}
-            <h2 class="text-2xl font-bold text-cyan-300 text-center mb-1">{{ vps.name }}</h2>
-            <div class="crt p-4 rounded overflow-x-auto mb-4">
-                <div class="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
-                    <span class="text-gray-400">供应商</span><span>{{ vps.vendor_name or '-' }}</span>
-                    <span class="text-gray-400">配置</span><span>{{ vps.instance_config or '-' }}</span>
-                    <span class="text-gray-400">位置</span><span>{{ vps.location or '-' }}</span>
-                    <span class="text-gray-400">流量限制</span><span>{{ vps.traffic_limit or '-' }}</span>
-                    {% set ip_display = '-' %}{% if vps.ip_address %}{% set parts = vps.ip_address.split('.') %}{% set ip_display = parts[:-1]|join('.') ~ '.**' %}{% endif %}
-                    <span class="text-gray-400">IP 地址</span><span>{{ ip_display }}</span>
-                    <span class="text-gray-400">交易时间</span><span>{{ vps.transaction_date or '-' }}</span>
-                    <span class="text-gray-400">到期时间</span><span>{{ vps.expiry_date or '-' }}</span>
-                    <span class="text-gray-400">续费金额</span><span>{{ vps.renewal_price or '-' }} {{ vps.currency }}</span>
-                    <span class="text-gray-400">支付方式</span><span>{{ vps.payment_method or '-' }}</span>
-                    <span class="text-gray-400">手续费</span><span>{{ vps.transaction_fee or '-' }} {{ vps.currency }}</span>
-                    <span class="text-gray-400">币种</span><span>{{ vps.currency or '-' }}</span>
-                    <span class="text-gray-400">续费周期</span><span>{% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</span>
-                    <span class="text-gray-400">实时汇率</span><span>{{ vps.exchange_rate }}</span>
-                    <span class="text-gray-400">剩余天数</span><span class="text-green-400 font-bold">{{ data.remaining_days }}</span>
-                    <span class="text-gray-400">剩余价值</span><span class="text-green-400 font-bold">{{ data.remaining_value }} CNY</span>
-                </div>
+            <h3 class="vps-title">{{ vps.name }}</h3>
+            <div class="vps-content">
+                <div class="vps-row"><span>商家：</span><span>{{ vps.vendor_name or '-' }}</span></div>
+                <div class="vps-row"><span>CPU：</span><span>{{ specs.cpu }}</span></div>
+                <div class="vps-row"><span>内存：</span><span>{{ specs.memory }}</span></div>
+                <div class="vps-row"><span>存储：</span><span>{{ specs.storage }}</span></div>
+                <div class="vps-row"><span>月流量：</span><span>{{ vps.traffic_limit or '-' }}</span></div>
+                {% set ip_display = '-' %}{% if vps.ip_address %}{% set parts = vps.ip_address.split('.') %}{% set ip_display = parts[:-1]|join('.') ~ '.**' %}{% endif %}
+                <div class="vps-row"><span>IP 地址：</span><span>{{ ip_display }}</span></div>
+                <div class="vps-row"><span>续费金额：</span><span>{{ vps.renewal_price or '-' }} {{ vps.currency }} / {% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</span></div>
+                <div class="vps-row"><span>剩余天数：</span><span>{{ data.remaining_days }} 天 ({{ vps.expiry_date or '-' }})</span></div>
+                <div class="vps-row"><span>剩余价值：</span><span>{{ data.remaining_value }} CNY / {{ data.total_value }} CNY</span></div>
+                <div class="vps-row"><span>描述说明：</span><span>{{ vps.description or '-' }}</span></div>
             </div>
-        </a>
+        </div>
         {% endfor %}
     </div>
     {% else %}
     <p class="text-center">暂无 VPS 条目。</p>
     {% endif %}
 </div>
+
+<script>
+    document.querySelectorAll('.vps-card').forEach(card => {
+        card.addEventListener('click', () => {
+            window.location.href = card.dataset.href;
+        });
+    });
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- display vendor, specs, renewal info and values on each VPS card with clickable navigation
- parse instance configuration and total value server-side
- add monospace terminal-style CSS and copy-link behavior on SVG page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f2d26fbc0832a858ab3776584c0fc