### PR TITLE
feat: refresh theme colors

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -16,19 +16,35 @@
   width: 360px;
   height: 520px;
   padding: 1rem;
-  background: linear-gradient(145deg, #1f1f1f, #151515);
-  border-radius: 12px;
-  box-shadow: 0 0 10px #00ff66;
-  border: 1px solid rgba(0, 255, 102, 0.3);
+  background-color: var(--card-bg);
+  border-radius: var(--border-radius);
+  box-shadow: var(--box-shadow);
+  border: 1px solid var(--card-border);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   font-family: 'Courier New', monospace;
-  color: #00ff66;
+  color: var(--font-color);
   cursor: pointer;
 }
 
 .vps-card:hover {
   transform: translateY(-5px);
-  box-shadow: 0 0 16px #00ff66;
+  box-shadow: 0 0 20px rgba(62, 255, 124, 0.3);
+}
+
+/* 灰色状态 */
+.vps-card.sold,
+.vps-card.inactive {
+  color: #6b7280;
+}
+
+.vps-card.sold .vps-title,
+.vps-card.inactive .vps-title,
+.vps-card.sold .vps-row span,
+.vps-card.inactive .vps-row span,
+.vps-card.sold .status-badge,
+.vps-card.inactive .status-badge {
+  color: #6b7280;
+  border-left-color: #6b7280;
 }
 
 /* 状态角标 */
@@ -39,11 +55,12 @@
   padding: 0.2rem 0.5rem;
   font-size: 0.7rem;
   font-weight: bold;
-  background-color: #00ffae;
-  color: #000;
+  background-color: #21262d;
+  color: var(--highlight-green);
+  border-left: 4px solid var(--card-border);
   border-bottom-right-radius: 0.5rem;
   border-top-left-radius: 0.4rem;
-  box-shadow: 0 0 6px rgba(0, 255, 170, 0.4);
+  box-shadow: 0 0 6px rgba(62, 255, 124, 0.4);
   z-index: 10;
 }
 
@@ -51,10 +68,11 @@
 .vps-title {
   font-size: 1.5rem;
   text-align: center;
-  color: #00ff00;
+  color: var(--font-blue);
   font-weight: bold;
 }
 
+/* 内容 */
 .vps-content {
   margin-top: 1rem;
   display: flex;
@@ -66,6 +84,15 @@
   display: flex;
   justify-content: space-between;
   margin-bottom: 0.25rem;
-  border-bottom: 1px solid rgba(0, 255, 102, 0.2);
+  border-bottom: 1px solid rgba(62, 255, 124, 0.2);
   padding-bottom: 0.25rem;
+}
+
+.vps-row span:first-child {
+  color: var(--font-green);
+  font-weight: 500;
+}
+
+.vps-row span:last-child {
+  color: var(--font-color);
 }

--- a/static/css/crt.css
+++ b/static/css/crt.css
@@ -1,12 +1,31 @@
+/* Theme variables */
+:root {
+  --bg-color: #0d1117;
+  --card-bg: #161b22;
+  --card-border: #3eff7c;
+  --font-color: #c9d1d9;
+  --font-green: #a6e22e;
+  --font-blue: #58a6ff;
+  --highlight-green: #8aff80;
+  --border-radius: 12px;
+  --box-shadow: 0 0 15px rgba(62, 255, 124, 0.2);
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--font-color);
+  font-family: 'Fira Code', 'Courier New', monospace;
+}
+
 .crt {
-  background-color: #000;
-  color: #00ff00;
+  background-color: var(--bg-color);
+  color: var(--highlight-green);
   font-family: 'Share Tech Mono', monospace;
-  box-shadow: 0 0 4px #0f0, 0 0 10px #0f0;
+  box-shadow: 0 0 4px var(--highlight-green), 0 0 10px var(--highlight-green);
   background-image: repeating-linear-gradient(
     to bottom,
-    rgba(0, 255, 0, 0.05),
-    rgba(0, 255, 0, 0.05) 1px,
+    rgba(138, 255, 128, 0.05),
+    rgba(138, 255, 128, 0.05) 1px,
     transparent 2px,
     transparent 4px
   );
@@ -26,5 +45,6 @@
 .crt svg {
   width: 100%;
   height: auto;
-  fill: #00ff00;
+  fill: var(--highlight-green);
 }
+

--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -1,7 +1,7 @@
 input[type="date"] {
-  background-color: #000;
-  color: #0f0;
-  border: 1px solid #0f0;
+  background-color: var(--bg-color);
+  color: var(--font-green);
+  border: 1px solid var(--font-green);
   padding: 0.5rem;
   border-radius: 6px;
 }

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -8,7 +8,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/crt.css') }}">
 </head>
-<body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono">
+<body class="min-h-screen font-mono">
 <nav class="flex justify-between items-center px-6 py-4 bg-black/80 backdrop-blur shadow-lg border-b border-cyan-400">
     <h1 class="text-3xl font-extrabold text-cyan-300 tracking-widest">
         <a href="{{ url_for('vps_list') }}">⚡ VPS 价值</a>

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/crt.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/cards.css') }}">
 </head>
-<body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono">
+<body class="min-h-screen font-mono">
 <nav class="flex justify-between items-center px-6 py-4 bg-black/80 backdrop-blur shadow-lg border-b border-cyan-400">
     <h1 class="text-3xl font-extrabold text-cyan-300 tracking-widest">
         <a href="{{ url_for('vps_list') }}">⚡ VPS 价值</a>
@@ -35,13 +35,13 @@
     {% if vps_data %}
     <div class="card-container">
         {% for vps, data, specs in vps_data %}
-        <div class="vps-card relative" data-href="{{ url_for('view_vps', name=vps.name) }}">
+        <div class="vps-card relative {% if vps.status == 'sold' %}sold{% elif vps.status == 'inactive' %}inactive{% endif %}" data-href="{{ url_for('view_vps', name=vps.name) }}">
             {% if vps.status == 'active' %}
-            <span class="status-badge bg-green-500">在使用</span>
+            <span class="status-badge">在使用</span>
             {% elif vps.status == 'sold' %}
-            <span class="status-badge bg-yellow-500">已转让</span>
+            <span class="status-badge">已转让</span>
             {% elif vps.status == 'inactive' %}
-            <span class="status-badge bg-gray-500">已停用</span>
+            <span class="status-badge">已停用</span>
             {% endif %}
             <h3 class="vps-title">{{ vps.name }}</h3>
             <div class="vps-content">

--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -1,24 +1,24 @@
 <svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
   <style>
     .title {
-      fill: #00d9ff;
+      fill: #58a6ff;
       font-size: 24px;
       font-family: 'Share Tech Mono', monospace;
       font-weight: bold;
     }
     .label {
-      fill: #00ff00;
+      fill: #8aff80;
       font-size: 16px;
       font-family: 'Courier New', monospace;
     }
     .footer {
-      fill: #888;
+      fill: #8aff80;
       font-size: 12px;
       font-family: 'Courier New', monospace;
     }
     rect {
-      fill: #000000;
-      stroke: #00ff00;
+      fill: #0d1117;
+      stroke: #3eff7c;
       stroke-width: 2;
       rx: 10;
       ry: 10;


### PR DESCRIPTION
## Summary
- add global theme variables for modern terminal look
- restyle VPS cards and status badges, greying sold or inactive entries
- align forms and SVG output with the new palette

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3a20624c832abc637668b116f6be