### PR TITLE
Fix VPS page layout and link copy

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -18,7 +18,7 @@
   padding: 1rem;
   background-color: var(--card-bg);
   border-radius: var(--border-radius);
-  box-shadow: var(--box-shadow);
+  box-shadow: 0 0 15px rgba(62, 255, 124, 0.4);
   border: 1px solid var(--card-border);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   font-family: 'Courier New', monospace;
@@ -28,7 +28,7 @@
 
 .vps-card:hover {
   transform: translateY(-5px);
-  box-shadow: 0 0 20px rgba(62, 255, 124, 0.3);
+  box-shadow: 0 0 25px rgba(62, 255, 124, 0.6);
 }
 
 /* 灰色状态 */
@@ -70,6 +70,7 @@
   text-align: center;
   color: var(--font-blue);
   font-weight: bold;
+  margin-top: 1.5rem;
 }
 
 /* 内容 */

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -40,7 +40,7 @@
     </div>
     <script>
         document.getElementById('copyLinkBtn').addEventListener('click', function () {
-            const text = `![image]({{ svg_abs_url }})`;
+            const text = {{ svg_abs_url|tojson }};
             navigator.clipboard.writeText(text).then(() => {
                 alert('链接已复制');
             }).catch(() => {

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -55,7 +55,7 @@
                 <div class="vps-row"><span>续费金额：</span><span>{{ vps.renewal_price or '-' }} {{ vps.currency }}</span></div>
                 <div class="vps-row"><span>续费周期：</span><span>{% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</span></div>
                 <div class="vps-row"><span>剩余天数：</span><span>{{ data.remaining_days }} 天</span></div>
-                <div class="vps-row"><span>剩余价值：</span><span>{{ data.remaining_value }} CNY / {{ data.total_value }} CNY</span></div>
+                <div class="vps-row"><span>剩余价值：</span><span>{{ data.remaining_value }} CNY</span></div>
                 <div class="vps-row"><span>描述说明：</span><span>{{ vps.description or '-' }}</span></div>
             </div>
         </div>

--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -12,7 +12,7 @@
       font-family: 'Courier New', monospace;
     }
     .footer {
-      fill: #8aff80;
+      fill: #6b7280;
       font-size: 12px;
       font-family: 'Courier New', monospace;
     }


### PR DESCRIPTION
## Summary
- add glow and spacing to VPS cards to prevent status/title overlap
- simplify remaining value display
- copy-link button now copies absolute image URL and SVG footer uses gray text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3d6bef90832a892ae3e5309644cf