### PR TITLE
feat: show renewal date before cycle

### DIFF
--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -130,6 +130,10 @@
               <fieldset className="border-b border-cyan-500 pb-4 mb-4">
                 <legend className="text-lg mb-2 text-cyan-300">续费信息</legend>
                 <div className="flex flex-col">
+                  <label className="mb-1 text-cyan-200">续费日期</label>
+                  <input type="date" name="transaction_date" value={form.transaction_date} onChange={handleChange} placeholder="请选择续费时间" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" required />
+                </div>
+                <div className="flex flex-col mt-4">
                   <label className="mb-1 text-cyan-200">续费周期</label>
                   <select name="renewal_days" value={form.renewal_days} onChange={handleChange} className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white focus:ring-2 focus:ring-cyan-400">
                     <option value="30">每月</option>
@@ -182,14 +186,6 @@
                   <label className="mb-1 text-cyan-200">实时汇率 (→ CNY)</label>
                   <input type="number" step="0.0001" name="exchange_rate" value={form.exchange_rate} onChange={handleChange} readOnly={form.exchange_rate_source === 'system'} className={`w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none ${form.exchange_rate_source === 'system' ? 'opacity-75' : ''}`} />
                   {form.exchange_rate_source === 'system' && <span className="absolute right-2 top-8">🔄</span>}
-                </div>
-              </fieldset>
-
-              <fieldset className="border-b border-cyan-500 pb-4 mb-4">
-                <legend className="text-lg mb-2 text-cyan-300">时间信息</legend>
-                <div className="flex flex-col">
-                  <label className="mb-1 text-cyan-200">交易日期</label>
-                  <input type="date" name="transaction_date" value={form.transaction_date} onChange={handleChange} placeholder="请选择交易时间" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" required />
                 </div>
               </fieldset>
 

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -53,6 +53,7 @@
                 {% set ip_display = '-' %}{% if vps.ip_address %}{% set parts = vps.ip_address.split('.') %}{% set ip_display = parts[:-1]|join('.') ~ '.**' %}{% endif %}
                 <div class="vps-row"><span>IP 地址：</span><span>{{ ip_display }}</span></div>
                 <div class="vps-row"><span>续费金额：</span><span>{{ vps.renewal_price or '-' }} {{ vps.currency }}</span></div>
+                <div class="vps-row"><span>续费日期：</span><span>{{ vps.transaction_date.strftime('%Y-%m-%d') if vps.transaction_date else '-' }}</span></div>
                 <div class="vps-row"><span>续费周期：</span><span>{% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</span></div>
                 <div class="vps-row"><span>剩余天数：</span><span>{{ data.remaining_days }} 天</span></div>
                 <div class="vps-row"><span>剩余价值：</span><span>{{ data.remaining_value }} CNY</span></div>

--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -30,11 +30,12 @@
 
   <text x="30" y="80" class="label">商家： {{ vps.vendor_name or '-' }}</text>
   <text x="30" y="105" class="label">配置： {{ specs.cpu }} / {{ specs.memory }} / {{ specs.storage }}</text>
-  <text x="30" y="130" class="label">续费周期： {% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</text>
-  <text x="30" y="155" class="label">续费金额： {{ vps.renewal_price }} {{ vps.currency }}</text>
-  <text x="30" y="180" class="label">剩余天数： {{ data.remaining_days }}</text>
-  <text x="30" y="205" class="label">剩余价值： {{ data.remaining_value }} 元</text>
+  <text x="30" y="130" class="label">续费日期： {{ vps.transaction_date.strftime('%Y/%m/%d') if vps.transaction_date else '-' }}</text>
+  <text x="30" y="155" class="label">续费周期： {% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</text>
+  <text x="30" y="180" class="label">续费金额： {{ vps.renewal_price }} {{ vps.currency }}</text>
+  <text x="30" y="205" class="label">剩余天数： {{ data.remaining_days }}</text>
+  <text x="30" y="230" class="label">剩余价值： {{ data.remaining_value }} 元</text>
 
-  <text x="30" y="250" class="footer">更新时间：{{ today.strftime('%Y/%m/%d') }}</text>
-  <text x="30" y="270" class="footer">Noodseek ID：{{ config.noodseek_id if config else '' }}</text>
+  <text x="30" y="275" class="footer">更新时间：{{ today.strftime('%Y/%m/%d') }}</text>
+  <text x="30" y="295" class="footer">Noodseek ID：{{ config.noodseek_id if config else '' }}</text>
 </svg>


### PR DESCRIPTION
## Summary
- display renewal date ahead of renewal cycle on VPS cards and SVGs
- capture renewal date in VPS form alongside cycle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3ed5bb98832aac95f795d8a9d3b0