### PR TITLE
Use purchase date and improve instance config parsing

### DIFF
--- a/app.py
+++ b/app.py
@@ -62,7 +62,7 @@ def init_sample():
         if db.query(VPS).count() == 0:
             sample = VPS(
                 name="demo",
-                transaction_date=date.today(),
+                purchase_date=date.today(),
                 renewal_days=30,
                 renewal_price=10.0,
                 currency="USD",
@@ -192,7 +192,7 @@ def add_vps():
         with Session(engine) as db:
             vps = VPS(
                 name=form["name"],
-                transaction_date=date.fromisoformat(form["transaction_date"]),
+                purchase_date=date.fromisoformat(form["purchase_date"]),
                 renewal_days=int(form.get("renewal_days") or 0),
                 renewal_price=float(form.get("renewal_price") or 0.0),
                 currency=form["currency"],
@@ -237,7 +237,7 @@ def edit_vps(vps_id: int):
         if request.method == "POST":
             form = request.form
             vps.name = form["name"]
-            vps.transaction_date = date.fromisoformat(form["transaction_date"])
+            vps.purchase_date = date.fromisoformat(form["purchase_date"])
             vps.renewal_days = int(form["renewal_days"] or 0)
             vps.renewal_price = float(form["renewal_price"] or 0.0)
             vps.currency = form["currency"]
@@ -261,7 +261,7 @@ def edit_vps(vps_id: int):
             return redirect(url_for("manage_vps"))
         vps_data = {
             "name": vps.name,
-            "transaction_date": vps.transaction_date.isoformat(),
+            "purchase_date": vps.purchase_date.isoformat(),
             "renewal_days": vps.renewal_days,
             "renewal_price": vps.renewal_price,
             "currency": vps.currency,

--- a/app/models.py
+++ b/app/models.py
@@ -7,7 +7,8 @@ class VPS(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, unique=True, index=True)
-    transaction_date = Column(Date)
+    # purchase_date stored in 'transaction_date' column for backward compatibility
+    purchase_date = Column("transaction_date", Date)
     cycle_base_date = Column(Date)
     expiry_date = Column(Date)
     renewal_days = Column(Integer)

--- a/app/utils.py
+++ b/app/utils.py
@@ -22,7 +22,7 @@ def add_months(dt: date, months: int) -> date:
 
 def calculate_remaining(vps):
     today = date.today()
-    if not vps.transaction_date or not vps.renewal_days:
+    if not vps.purchase_date or not vps.renewal_days:
         return {
             "remaining_days": 0,
             "remaining_value": 0.0,
@@ -32,7 +32,7 @@ def calculate_remaining(vps):
         }
 
     months_map = {30: 1, 90: 3, 365: 12, 1095: 36}
-    start = vps.transaction_date
+    start = vps.purchase_date
     if vps.renewal_days in months_map:
         months = months_map[vps.renewal_days]
         while add_months(start, months) <= today:
@@ -68,13 +68,13 @@ def calculate_remaining(vps):
 
 
 def parse_instance_config(config: str):
-    """Parse instance configuration like '2C2G120G' into cpu/memory/storage."""
+    """Parse instance configuration like '2C2G120G' or '8C/0.5G/41G' into cpu/memory/storage."""
     cpu = memory = storage = "-"
     if not config:
         return {"cpu": cpu, "memory": memory, "storage": storage}
 
     # Normalize and find all numbers followed by letters
-    matches = re.findall(r"(\d+)\s*([A-Za-z]+)", config)
+    matches = re.findall(r"(\d+(?:\.\d+)?)\s*([A-Za-z]+)", config)
     for value, unit in matches:
         unit = unit.lower()
         if unit.startswith("c") and cpu == "-":

--- a/cli.py
+++ b/cli.py
@@ -50,12 +50,12 @@ def add_vps():
     currency = input("Currency (e.g., USD, CNY, EUR): ").strip().upper() or "USD"
     price = float(input("Renewal price: ").strip())
     cycle_days = choose_cycle()
-    transaction_date = prompt_date("Transaction date (YYYY-MM-DD, default today): ", date.today())
+    purchase_date = prompt_date("Purchase date (YYYY-MM-DD, default today): ", date.today())
     rate = fetch_rate(currency)
     with Session(engine) as db:
         vps = VPS(
             name=name,
-            transaction_date=transaction_date,
+            purchase_date=purchase_date,
             renewal_days=cycle_days,
             renewal_price=price,
             currency=currency,

--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -41,7 +41,7 @@
       const today = new Date().toISOString().split('T')[0];
       const defaultData = {
         name: '',
-        transaction_date: today,
+        purchase_date: today,
         renewal_days: '30',
         renewal_price: '',
         currency: 'USD',
@@ -130,8 +130,8 @@
               <fieldset className="border-b border-cyan-500 pb-4 mb-4">
                 <legend className="text-lg mb-2 text-cyan-300">续费信息</legend>
                 <div className="flex flex-col">
-                  <label className="mb-1 text-cyan-200">续费日期</label>
-                  <input type="date" name="transaction_date" value={form.transaction_date} onChange={handleChange} placeholder="请选择续费时间" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" required />
+                  <label className="mb-1 text-cyan-200">购买日期</label>
+                  <input type="date" name="purchase_date" value={form.purchase_date} onChange={handleChange} placeholder="请选择购买时间" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" required />
                 </div>
                 <div className="flex flex-col mt-4">
                   <label className="mb-1 text-cyan-200">续费周期</label>
@@ -193,7 +193,7 @@
                 <legend className="text-lg mb-2 text-cyan-300">系统信息</legend>
                 <div className="flex flex-col">
                   <label className="mb-1 text-cyan-200">实例配置</label>
-                  <input name="instance_config" value={form.instance_config} onChange={handleChange} placeholder="如 2核2G/30G SSD" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
+                  <input name="instance_config" value={form.instance_config} onChange={handleChange} placeholder="如 8C/0.5G/41G 或 8C 0.5G 41G" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
                 </div>
                 <div className="flex flex-col mt-4">
                   <label className="mb-1 text-cyan-200">所在机房</label>

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -53,7 +53,7 @@
                 {% set ip_display = '-' %}{% if vps.ip_address %}{% set parts = vps.ip_address.split('.') %}{% set ip_display = parts[:-1]|join('.') ~ '.**' %}{% endif %}
                 <div class="vps-row"><span>IP 地址：</span><span>{{ ip_display }}</span></div>
                 <div class="vps-row"><span>续费金额：</span><span>{{ vps.renewal_price or '-' }} {{ vps.currency }}</span></div>
-                <div class="vps-row"><span>续费日期：</span><span>{{ vps.transaction_date.strftime('%Y-%m-%d') if vps.transaction_date else '-' }}</span></div>
+                <div class="vps-row"><span>购买日期：</span><span>{{ vps.purchase_date.strftime('%Y-%m-%d') if vps.purchase_date else '-' }}</span></div>
                 <div class="vps-row"><span>续费周期：</span><span>{% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</span></div>
                 <div class="vps-row"><span>剩余天数：</span><span>{{ data.remaining_days }} 天</span></div>
                 <div class="vps-row"><span>剩余价值：</span><span>{{ data.remaining_value }} CNY</span></div>

--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -30,7 +30,7 @@
 
   <text x="30" y="80" class="label">商家： {{ vps.vendor_name or '-' }}</text>
   <text x="30" y="105" class="label">配置： {{ specs.cpu }} / {{ specs.memory }} / {{ specs.storage }}</text>
-  <text x="30" y="130" class="label">续费日期： {{ vps.transaction_date.strftime('%Y/%m/%d') if vps.transaction_date else '-' }}</text>
+  <text x="30" y="130" class="label">购买日期： {{ vps.purchase_date.strftime('%Y/%m/%d') if vps.purchase_date else '-' }}</text>
   <text x="30" y="155" class="label">续费周期： {% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</text>
   <text x="30" y="180" class="label">续费金额： {{ vps.renewal_price }} {{ vps.currency }}</text>
   <text x="30" y="205" class="label">剩余天数： {{ data.remaining_days }}</text>

--- a/tests/test_add_vps.py
+++ b/tests/test_add_vps.py
@@ -29,7 +29,7 @@ def test_add_vps_with_optional_fields(client):
     vps_name = f"vps_{uuid.uuid4().hex}"
     data = {
         'name': vps_name,
-        'transaction_date': '2024-01-01',
+        'purchase_date': '2024-01-01',
         'renewal_days': '',
         'renewal_price': '',
         'currency': 'USD',

--- a/tests/test_parse_instance_config.py
+++ b/tests/test_parse_instance_config.py
@@ -1,0 +1,8 @@
+from app.utils import parse_instance_config
+
+
+def test_parse_instance_config_formats():
+    expected = {"cpu": "8C", "memory": "0.5G", "storage": "41G"}
+    configs = ["8C/0.5G/41G", "8C 0.5G 41G", "8C|0.5G|41G"]
+    for cfg in configs:
+        assert parse_instance_config(cfg) == expected


### PR DESCRIPTION
## Summary
- track VPS purchase date instead of renewal date and compute value by cycle
- allow instance configuration parsing for decimals and multiple separators
- add test coverage for parsing variations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f40b63408832a97b8403709df6b7a