### PR TITLE
Add IP masking and geolocation to VPS list

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -79,14 +79,60 @@ def parse_instance_config(config: str):
         unit = unit.lower()
         if unit.startswith("c") and cpu == "-":
             cpu = f"{value}C"
-        elif unit.startswith("g") and memory == "-":
-            memory = f"{value}G"
-        elif unit.startswith("g") and memory != "-" and storage == "-":
-            storage = f"{value}G"
-        elif unit.startswith("t") and storage == "-":
-            storage = f"{value}T"
+            continue
+
+        unit_map = {
+            "g": "G",
+            "gb": "GB",
+            "m": "M",
+            "mb": "MB",
+            "t": "T",
+            "tb": "TB",
+        }
+
+        if unit in unit_map:
+            pretty = unit_map[unit]
+            if memory == "-":
+                memory = f"{value}{pretty}"
+            elif storage == "-":
+                storage = f"{value}{pretty}"
 
     return {"cpu": cpu, "memory": memory, "storage": storage}
+
+
+def mask_ip(ip: str) -> str:
+    """Mask the middle two octets of an IPv4 address."""
+    parts = ip.split(".")
+    if len(parts) == 4:
+        return f"{parts[0]}.**.**.{parts[3]}"
+    return ip
+
+
+def ping_ip(ip: str) -> str:
+    """Ping IP once and return Chinese status string."""
+    import subprocess
+
+    try:
+        res = subprocess.run(
+            ["ping", "-c", "1", "-W", "1", ip],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return "在线" if res.returncode == 0 else "离线"
+    except Exception:
+        return "未知"
+
+
+def ip_to_flag(ip: str) -> str:
+    """Return emoji flag for IP using ipapi.co."""
+    try:
+        resp = requests.get(f"https://ipapi.co/{ip}/country/", timeout=5)
+        code = resp.text.strip().upper()
+        if len(code) == 2 and code.isalpha():
+            return chr(ord(code[0]) + 127397) + chr(ord(code[1]) + 127397)
+    except Exception:
+        pass
+    return "🏳️"
 
 
 def generate_svg(vps, data, config=None):

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -36,8 +36,7 @@
             <div><dt>商家：</dt><dd>{{ vps.vendor_name or '-' }}</dd></div>
             <div><dt>配置：</dt><dd>{{ specs.cpu }} / {{ specs.memory }} / {{ specs.storage }}</dd></div>
             <div><dt>月流量：</dt><dd>{{ vps.traffic_limit or '-' }}</dd></div>
-            {% set ip_display = '-' %}{% if vps.ip_address %}{% set parts = vps.ip_address.split('.') %}{% set ip_display = parts[:-1]|join('.') ~ '.**' %}{% endif %}
-            <div><dt>IP 地址：</dt><dd>{{ ip_display }}</dd></div>
+            <div><dt>IP 地址：</dt><dd>{{ ip_info.flag }} {{ ip_info.ip_display }} ({{ ip_info.ping_status }})</dd></div>
             <div><dt>到期时间：</dt><dd>{{ data.cycle_end.strftime('%Y/%m/%d') if data.cycle_end else '-' }}</dd></div>
             <div><dt>续费金额：</dt><dd>{{ vps.renewal_price or '-' }} {{ vps.currency }}</dd></div>
             <div><dt>剩余天数：</dt><dd>{{ data.remaining_days }} 天</dd></div>

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -34,7 +34,7 @@
     <h1 class="text-center text-4xl font-bold text-cyan-300 mb-8">VPS 列表</h1>
     {% if vps_data %}
     <div class="card-container">
-        {% for vps, data, specs in vps_data %}
+        {% for vps, data, specs, ip_info in vps_data %}
         <div class="vps-card relative {% if vps.status == 'sold' %}sold{% elif vps.status == 'inactive' %}inactive{% endif %}" data-href="{{ url_for('view_vps', name=vps.name) }}">
             {% if vps.status == 'active' %}
             <span class="status-badge">在使用</span>
@@ -50,8 +50,7 @@
                 <div class="vps-row"><span>内存：</span><span>{{ specs.memory }}</span></div>
                 <div class="vps-row"><span>存储：</span><span>{{ specs.storage }}</span></div>
                 <div class="vps-row"><span>月流量：</span><span>{{ vps.traffic_limit or '-' }}</span></div>
-                {% set ip_display = '-' %}{% if vps.ip_address %}{% set parts = vps.ip_address.split('.') %}{% set ip_display = parts[:-1]|join('.') ~ '.**' %}{% endif %}
-                <div class="vps-row"><span>IP 地址：</span><span>{{ ip_display }}</span></div>
+                <div class="vps-row"><span>IP 地址：</span><span>{{ ip_info.flag }} {{ ip_info.ip_display }} ({{ ip_info.ping_status }})</span></div>
                 <div class="vps-row"><span>续费金额：</span><span>{{ vps.renewal_price or '-' }} {{ vps.currency }}</span></div>
                 <div class="vps-row"><span>购买日期：</span><span>{{ vps.purchase_date.strftime('%Y-%m-%d') if vps.purchase_date and vps.status == 'active' else '-' }}</span></div>
                 <div class="vps-row"><span>续费周期：</span><span>{% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</span></div>

--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -30,7 +30,9 @@
 
   <text x="30" y="80" class="label">商家： {{ vps.vendor_name or '-' }}</text>
   <text x="30" y="105" class="label">配置： {{ specs.cpu }} / {{ specs.memory }} / {{ specs.storage }}</text>
-  <text x="30" y="130" class="label">购买日期： {{ vps.purchase_date.strftime('%Y/%m/%d') if vps.purchase_date else '-' }}</text>
+  <text x="30" y="130" class="label">
+    购买日期： {{ vps.purchase_date.strftime('%Y/%m/%d') if vps.purchase_date else '-' }}
+  </text>
   <text x="30" y="155" class="label">续费周期： {% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</text>
   <text x="30" y="180" class="label">续费金额： {{ vps.renewal_price }} {{ vps.currency }}</text>
   <text x="30" y="205" class="label">剩余天数： {{ data.remaining_days }}</text>

--- a/tests/test_parse_instance_config.py
+++ b/tests/test_parse_instance_config.py
@@ -6,3 +6,9 @@ def test_parse_instance_config_formats():
     configs = ["8C/0.5G/41G", "8C 0.5G 41G", "8C|0.5G|41G"]
     for cfg in configs:
         assert parse_instance_config(cfg) == expected
+
+
+def test_parse_instance_config_various_units():
+    cfg = "4C/512MB/1TB"
+    expected = {"cpu": "4C", "memory": "512MB", "storage": "1TB"}
+    assert parse_instance_config(cfg) == expected


### PR DESCRIPTION
## Summary
- parse instance specs with MB/GB/TB units
- show masked IP with ping status and country flag on VPS pages
- correct SVG template formatting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f45e94bf0832abbe06a6d1d15ede1