### PR TITLE
Improve VPS card layout and ping updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -355,8 +355,13 @@ def vps_list():
                 ip_info["ip_display"] = mask_ip(vps.ip_address)
                 ip_info["ping_status"] = ping_ip(vps.ip_address)
                 ip_info["flag"] = ip_to_flag(vps.ip_address)
-            vps_data.append((vps, data, specs, ip_info))
+        vps_data.append((vps, data, specs, ip_info))
     return render_template("vps.html", vps_data=vps_data)
+
+
+@app.route("/ping/<path:ip>")
+def ping_status(ip: str):
+    return ping_ip(ip)
 
 
 @app.route("/vps/<string:name>")

--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -1,10 +1,16 @@
 /* Banner */
 .banner {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   padding: 1rem 1.5rem;
   background-color: rgba(0, 0, 0, 0.8);
   border-bottom: 1px solid var(--font-blue);
+}
+
+.banner-left {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .banner-title {
@@ -15,6 +21,11 @@
   font-family: 'JetBrains Mono', 'Courier New', monospace;
   font-weight: 700;
   color: var(--font-blue);
+}
+
+.banner-stats {
+  font-size: 1rem;
+  color: #ccc;
 }
 
 .banner-subinfo {
@@ -68,10 +79,14 @@
 .vps-card.sold .vps-title,
 .vps-card.inactive .vps-title,
 .vps-card.sold .vps-row span,
-.vps-card.inactive .vps-row span,
+.vps-card.inactive .vps-row span {
+  color: #6b7280;
+}
+
 .vps-card.sold .card-status-tag,
 .vps-card.inactive .card-status-tag {
-  color: #6b7280;
+  background: #6b7280;
+  color: #fff;
 }
 
 /* 状态标签 */

--- a/static/css/view_svg.css
+++ b/static/css/view_svg.css
@@ -32,7 +32,7 @@
 
 .vps-footer {
   margin-top: 1.5rem;
-  text-align: center;
+  text-align: right;
   font-size: 12px;
   color: rgba(255, 255, 255, 0.4);
 }

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -12,11 +12,15 @@
 </head>
 <body class="min-h-screen font-mono">
 <nav class="banner">
-    <div class="banner-title">
-        ⚡ <span>VPS</span> <span>剩余价值计算器</span>
+    <div class="banner-left">
+        <div class="banner-title">
+            ⚡ <span>VPS</span> <span>剩余价值计算器</span>
+        </div>
+        <div class="banner-stats">
+            在用主机：<strong>{{ site_stats.count }} 台</strong> / 总价值：<strong>{{ site_stats.total_value }} 元</strong>
+        </div>
     </div>
     <div class="banner-subinfo">
-        在用主机：<strong>{{ site_stats.count }} 台</strong> / 总价值：<strong>{{ site_stats.total_value }} 元</strong>
         {% if current_user %}
         <span>你好, {{ current_user.username }}</span>
         <a class="text-sm border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-3 py-1 rounded transition" href="{{ url_for('add_vps') }}">添加 VPS</a>
@@ -35,15 +39,15 @@
     <div class="svg-card">
         <h2 class="text-center text-cyan-300 text-xl mb-4 font-bold">{{ vps.name }}</h2>
         <dl class="vps-info-list">
-            <div><dt>商家：</dt><dd>{{ vps.vendor_name or '-' }}</dd></div>
-            <div><dt>配置：</dt><dd>{{ specs.cpu }} / {{ specs.memory }} / {{ specs.storage }}</dd></div>
-            <div><dt>月流量：</dt><dd>{{ vps.traffic_limit or '-' }}</dd></div>
-            <div><dt>IP 地址：</dt><dd>{{ ip_info.flag }} {{ ip_info.ip_display }} ({{ ip_info.ping_status }})</dd></div>
-            <div><dt>到期时间：</dt><dd>{{ data.cycle_end.strftime('%Y/%m/%d') if data.cycle_end else '-' }}</dd></div>
-            <div><dt>续费金额：</dt><dd>{{ vps.renewal_price or '-' }} {{ vps.currency }}</dd></div>
-            <div><dt>剩余天数：</dt><dd>{{ data.remaining_days }} 天</dd></div>
-            <div><dt>剩余价值：</dt><dd>{{ data.remaining_value }} 元</dd></div>
-            <div><dt>描述说明：</dt><dd>{{ vps.description or '-' }}</dd></div>
+            <dt>商家：</dt><dd>{{ vps.vendor_name or '-' }}</dd>
+            <dt>配置：</dt><dd>{{ specs.cpu }} / {{ specs.memory }} / {{ specs.storage }}</dd>
+            <dt>月流量：</dt><dd>{{ vps.traffic_limit or '-' }}</dd>
+            <dt>IP 地址：</dt><dd>{{ ip_info.flag }} {{ ip_info.ip_display }} (<span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span>)</dd>
+            <dt>到期时间：</dt><dd>{{ data.cycle_end.strftime('%Y/%m/%d') if data.cycle_end else '-' }}</dd>
+            <dt>续费金额：</dt><dd>{{ vps.renewal_price or '-' }} {{ vps.currency }}</dd>
+            <dt>剩余天数：</dt><dd>{{ data.remaining_days }} 天</dd>
+            <dt>剩余价值：</dt><dd>{{ data.remaining_value }} 元</dd>
+            <dt>描述说明：</dt><dd>{{ vps.description or '-' }}</dd>
         </dl>
         <div class="vps-footer">
             <p>更新时间: {{ today.strftime('%Y/%m/%d') }}</p>
@@ -57,13 +61,25 @@
     </div>
 </div>
 <script>
+    function updatePingStatus() {
+        document.querySelectorAll('.ping-status').forEach(el => {
+            const ip = el.dataset.ip;
+            fetch(`/ping/${ip}`).then(r => r.text()).then(t => {
+                el.textContent = t;
+            });
+        });
+    }
+    updatePingStatus();
+    setInterval(updatePingStatus, 60000);
+
     document.getElementById('copyLinkBtn').addEventListener('click', function () {
-        const text = {{ svg_abs_url|tojson }};
+        const url = {{ svg_abs_url|tojson }};
+        const text = `![image](${url})`;
         navigator.clipboard.writeText(text).then(() => {
             alert('链接已复制');
         }).catch(() => {
             alert('复制失败，请手动复制。');
-    });
+        });
     });
 </script>
 <footer class="py-4 text-center text-xs text-gray-400">© {{ config.copyright }}</footer>

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -11,11 +11,15 @@
 </head>
 <body class="min-h-screen font-mono">
 <nav class="banner">
-    <div class="banner-title">
-        ⚡ <span>VPS</span> <span>剩余价值计算器</span>
+    <div class="banner-left">
+        <div class="banner-title">
+            ⚡ <span>VPS</span> <span>剩余价值计算器</span>
+        </div>
+        <div class="banner-stats">
+            在用主机：<strong>{{ site_stats.count }} 台</strong> / 总价值：<strong>{{ site_stats.total_value }} 元</strong>
+        </div>
     </div>
     <div class="banner-subinfo">
-        在用主机：<strong>{{ site_stats.count }} 台</strong> / 总价值：<strong>{{ site_stats.total_value }} 元</strong>
         {% if current_user %}
         <span>你好, {{ current_user.username }}</span>
         <a class="text-sm border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-3 py-1 rounded transition" href="{{ url_for('add_vps') }}">添加 VPS</a>
@@ -51,7 +55,7 @@
                 <div class="vps-row"><span>内存：</span><span>{{ specs.memory }}</span></div>
                 <div class="vps-row"><span>存储：</span><span>{{ specs.storage }}</span></div>
                 <div class="vps-row"><span>月流量：</span><span>{{ vps.traffic_limit or '-' }}</span></div>
-                <div class="vps-row"><span>IP 地址：</span><span>{{ ip_info.flag }} {{ ip_info.ip_display }} ({{ ip_info.ping_status }})</span></div>
+                <div class="vps-row"><span>IP 地址：</span><span>{{ ip_info.flag }} {{ ip_info.ip_display }} (<span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span>)</span></div>
                 <div class="vps-row"><span>续费金额：</span><span>{{ vps.renewal_price or '-' }} {{ vps.currency }}</span></div>
                 <div class="vps-row"><span>购买日期：</span><span>{{ vps.purchase_date.strftime('%Y-%m-%d') if vps.purchase_date and vps.status == 'active' else '-' }}</span></div>
                 <div class="vps-row"><span>续费周期：</span><span>{% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</span></div>
@@ -73,6 +77,17 @@
             window.location.href = card.dataset.href;
         });
     });
+
+    function updatePingStatus() {
+        document.querySelectorAll('.ping-status').forEach(el => {
+            const ip = el.dataset.ip;
+            fetch(`/ping/${ip}`).then(r => r.text()).then(t => {
+                el.textContent = t;
+            });
+        });
+    }
+    updatePingStatus();
+    setInterval(updatePingStatus, 60000);
 </script>
 <footer class="py-4 text-center text-xs text-gray-400">© {{ config.copyright }}</footer>
 

--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -36,6 +36,6 @@
   <text x="30" y="215" class="label">剩余天数： {{ data.remaining_days }}</text>
   <text x="30" y="240" class="label">剩余价值： {{ data.remaining_value }} 元</text>
 
-  <text x="30" y="400" class="footer">更新时间: {{ today.strftime('%Y/%m/%d') }}</text>
-  <text x="30" y="420" class="footer">NodeSeek ID: {{ config.noodseek_id if config else '' }}</text>
+  <text x="610" y="400" class="footer" text-anchor="end">更新时间: {{ today.strftime('%Y/%m/%d') }}</text>
+  <text x="610" y="420" class="footer" text-anchor="end">NodeSeek ID: {{ config.noodseek_id if config else '' }}</text>
 </svg>


### PR DESCRIPTION
## Summary
- Move overall stats beneath the title and style inactive/sold badges gray
- Refresh IP ping status every minute with a new `/ping` endpoint
- Clean up VPS detail view: one line per item, right-aligned footer, and working copy link

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f51084e10832a9c42c2fd85686272