### PR TITLE
Revamp admin page and site configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -100,8 +100,8 @@ def init_sample():
         if db.query(SiteConfig).count() == 0:
             db.add(
                 SiteConfig(
-                    image_base_url="",
-                    noodseek_id="@Flanker",
+                    site_url="",
+                    username="@Flanker",
                     copyright="xxx.com",
                 )
             )
@@ -189,19 +189,19 @@ def manage_users():
                     db.add(InviteCode(code=code))
                 db.commit()
             elif action == "set_site_config":
-                base_url = request.form.get("image_base_url", "")
-                noodseek_id = request.form.get("noodseek_id", "")
+                base_url = request.form.get("site_url", "")
+                username = request.form.get("username", "")
                 copyright = request.form.get("copyright", "")
                 cfg = db.query(SiteConfig).first()
                 if cfg:
-                    cfg.image_base_url = base_url
-                    cfg.noodseek_id = noodseek_id
+                    cfg.site_url = base_url
+                    cfg.username = username
                     cfg.copyright = copyright
                 else:
                     db.add(
                         SiteConfig(
-                            image_base_url=base_url,
-                            noodseek_id=noodseek_id,
+                            site_url=base_url,
+                            username=username,
                             copyright=copyright,
                         )
                     )
@@ -384,8 +384,8 @@ def view_vps(name: str):
             ip_info["flag"] = ip_to_flag(vps.ip_address)
         generate_svg(vps, data, config)
     svg_url = url_for("static", filename=f"images/{name}.svg")
-    if config and config.image_base_url:
-        svg_abs_url = f"{config.image_base_url.rstrip('/')}/{name}.svg"
+    if config and config.site_url:
+        svg_abs_url = f"{config.site_url.rstrip('/')}/{name}.svg"
     else:
         svg_abs_url = url_for("static", filename=f"images/{name}.svg", _external=True)
     return render_template(

--- a/app/db.py
+++ b/app/db.py
@@ -70,6 +70,20 @@ def _run_migrations():
         if "copyright" not in columns:
             with engine.begin() as conn:
                 conn.execute(text("ALTER TABLE site_config ADD COLUMN copyright TEXT"))
+        if "site_url" not in columns:
+            with engine.begin() as conn:
+                conn.execute(text("ALTER TABLE site_config ADD COLUMN site_url TEXT"))
+                if "image_base_url" in columns:
+                    conn.execute(
+                        text("UPDATE site_config SET site_url = image_base_url"),
+                    )
+        if "username" not in columns:
+            with engine.begin() as conn:
+                conn.execute(text("ALTER TABLE site_config ADD COLUMN username TEXT"))
+                if "noodseek_id" in columns:
+                    conn.execute(
+                        text("UPDATE site_config SET username = noodseek_id"),
+                    )
 
 
 _run_migrations()

--- a/app/models.py
+++ b/app/models.py
@@ -49,6 +49,6 @@ class SiteConfig(Base):
     __tablename__ = "site_config"
 
     id = Column(Integer, primary_key=True)
-    image_base_url = Column(String, default="")
-    noodseek_id = Column(String, default="@Flanker")
+    site_url = Column(String, default="")
+    username = Column(String, default="@Flanker")
     copyright = Column(String, default="xxx.com")

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -3,46 +3,102 @@
 <head>
     <meta charset="UTF-8">
     <title>用户管理</title>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/crt.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/cards.css') }}">
 </head>
-<body>
-    <h1>用户管理</h1>
-    <h2>邀请码管理</h2>
-    <form method="post" style="margin-bottom:20px;">
-        <input type="hidden" name="action" value="set_invite_code">
-        <input name="invite_code" value="{{ invite_code }}" placeholder="邀请码">
-        <button type="submit">更新邀请码</button>
-    </form>
-    <h2>站点配置</h2>
-    <form method="post" style="margin-bottom:20px;">
-        <input type="hidden" name="action" value="set_site_config">
-        <input name="image_base_url" value="{{ config.image_base_url if config else '' }}" placeholder="图片基础URL">
-        <input name="noodseek_id" value="{{ config.noodseek_id if config else '' }}" placeholder="Nodeseek ID">
-        <input name="copyright" value="{{ config.copyright if config else '' }}" placeholder="版权信息">
-        <button type="submit">更新配置</button>
-    </form>
-    <table border="1" cellpadding="5" cellspacing="0">
-        <tr><th>ID</th><th>用户名</th><th>管理员</th><th>操作</th></tr>
-        {% for user in users %}
-        <tr>
-            <td>{{ user.id }}</td>
-            <td>{{ user.username }}</td>
-            <td>{{ '是' if user.is_admin else '否' }}</td>
-            <td>
-                <form method="post" style="display:inline;">
-                    <input type="hidden" name="user_id" value="{{ user.id }}">
-                    <button name="action" value="toggle_admin" type="submit">
-                        {% if user.is_admin %}取消管理员{% else %}设为管理员{% endif %}
-                    </button>
-                </form>
-                <form method="post" style="display:inline;" onsubmit="return confirm('删除该用户？');">
-                    <input type="hidden" name="user_id" value="{{ user.id }}">
-                    <button name="action" value="delete" type="submit">删除</button>
-                </form>
-            </td>
-        </tr>
-        {% endfor %}
-    </table>
-    <footer class="py-4 text-center text-xs text-gray-400">© {{ config.copyright if config else '' }}</footer>
+<body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono">
+<nav class="banner">
+    <div class="banner-title">
+        ⚡ <span>VPS</span> <span>剩余价值计算器</span>
+    </div>
+    <div class="banner-subinfo">
+        在用主机：<strong>{{ site_stats.count }} 台</strong> / 总价值：<strong>{{ site_stats.total_value }} 元</strong>
+        {% if current_user %}
+        <span>你好, {{ current_user.username }}</span>
+        <a class="text-sm border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-3 py-1 rounded transition" href="{{ url_for('add_vps') }}">添加 VPS</a>
+        <a class="text-sm border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-3 py-1 rounded transition" href="{{ url_for('manage_vps') }}">管理 VPS</a>
+        {% if current_user.is_admin %}
+        <a class="text-sm border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-3 py-1 rounded transition" href="{{ url_for('manage_users') }}">用户管理</a>
+        {% endif %}
+        <a class="text-sm border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-3 py-1 rounded transition" href="{{ url_for('logout') }}">退出登录</a>
+        {% else %}
+        <a class="text-sm border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-3 py-1 rounded transition" href="{{ url_for('login') }}">登录</a>
+        <a class="text-sm border border-cyan-400 hover:bg-cyan-600 text-cyan-200 hover:text-white px-3 py-1 rounded transition" href="{{ url_for('register') }}">注册</a>
+        {% endif %}
+    </div>
+</nav>
+
+<div class="container mx-auto px-4 py-8">
+    <h1 class="text-center text-4xl font-bold text-cyan-300 mb-8">用户管理</h1>
+    <div class="grid gap-8 md:grid-cols-2 mb-8">
+        <div class="p-6 bg-[#111111] rounded-xl border border-cyan-400">
+            <h2 class="text-xl text-cyan-400 mb-4">邀请码管理</h2>
+            <form method="post" class="flex gap-2">
+                <input type="hidden" name="action" value="set_invite_code">
+                <input name="invite_code" value="{{ invite_code }}" placeholder="邀请码" class="flex-1 bg-black border border-cyan-500 rounded px-3 py-2 placeholder-gray-400">
+                <button type="submit" class="bg-blue-500 hover:bg-blue-400 text-white px-4 py-2 rounded">更新邀请码</button>
+            </form>
+        </div>
+        <div class="p-6 bg-[#111111] rounded-xl border border-cyan-400">
+            <h2 class="text-xl text-cyan-400 mb-4">站点配置</h2>
+            <form method="post" class="space-y-4">
+                <input type="hidden" name="action" value="set_site_config">
+                <div class="flex flex-col">
+                    <label class="text-cyan-200 mb-1">网址</label>
+                    <input name="site_url" value="{{ config.site_url if config else '' }}" placeholder="https://example.com" class="bg-black border border-cyan-500 rounded px-3 py-2 placeholder-gray-400">
+                </div>
+                <div class="flex flex-col">
+                    <label class="text-cyan-200 mb-1">用户名</label>
+                    <input name="username" value="{{ config.username if config else '' }}" placeholder="用户名" class="bg-black border border-cyan-500 rounded px-3 py-2 placeholder-gray-400">
+                </div>
+                <div class="flex flex-col">
+                    <label class="text-cyan-200 mb-1">版权信息</label>
+                    <input name="copyright" value="{{ config.copyright if config else '' }}" placeholder="版权信息" class="bg-black border border-cyan-500 rounded px-3 py-2 placeholder-gray-400">
+                </div>
+                <button type="submit" class="bg-blue-500 hover:bg-blue-400 text-white px-4 py-2 rounded">更新配置</button>
+            </form>
+        </div>
+    </div>
+
+    <div class="bg-[#111111] rounded-xl border border-cyan-400 p-6">
+        <h2 class="text-xl text-cyan-400 mb-4">用户列表</h2>
+        <table class="min-w-full text-sm">
+            <thead>
+                <tr class="text-left text-cyan-300 border-b border-cyan-400">
+                    <th class="py-2 px-3">ID</th>
+                    <th class="py-2 px-3">用户名</th>
+                    <th class="py-2 px-3">管理员</th>
+                    <th class="py-2 px-3">操作</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for user in users %}
+                <tr class="border-b border-gray-700">
+                    <td class="py-2 px-3">{{ user.id }}</td>
+                    <td class="py-2 px-3">{{ user.username }}</td>
+                    <td class="py-2 px-3">{{ '是' if user.is_admin else '否' }}</td>
+                    <td class="py-2 px-3 space-x-2">
+                        <form method="post" class="inline">
+                            <input type="hidden" name="user_id" value="{{ user.id }}">
+                            <button name="action" value="toggle_admin" type="submit" class="text-sm px-2 py-1 bg-green-600 rounded hover:bg-green-500 text-white">
+                                {% if user.is_admin %}取消管理员{% else %}设为管理员{% endif %}
+                            </button>
+                        </form>
+                        <form method="post" class="inline" onsubmit="return confirm('删除该用户？');">
+                            <input type="hidden" name="user_id" value="{{ user.id }}">
+                            <button name="action" value="delete" type="submit" class="text-sm px-2 py-1 bg-red-600 rounded hover:bg-red-500 text-white">删除</button>
+                        </form>
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+<footer class="py-4 text-center text-xs text-gray-400">© {{ config.copyright if config else '' }}</footer>
 </body>
 </html>
 

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -51,7 +51,7 @@
         </dl>
         <div class="vps-footer">
             <p>更新时间: {{ today.strftime('%Y/%m/%d') }}</p>
-            <p>Nodeseek ID: {{ config.noodseek_id if config and config.noodseek_id else '' }}</p>
+            <p>用户名: {{ config.username if config and config.username else '' }}</p>
         </div>
         <div class="card-buttons">
             <a href="{{ url_for('vps_list') }}">返回列表</a>

--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -37,5 +37,5 @@
   <text x="30" y="240" class="label">剩余价值： {{ data.remaining_value }} 元</text>
 
   <text x="610" y="400" class="footer" text-anchor="end">更新时间: {{ today.strftime('%Y/%m/%d') }}</text>
-  <text x="610" y="420" class="footer" text-anchor="end">NodeSeek ID: {{ config.noodseek_id if config else '' }}</text>
+  <text x="610" y="420" class="footer" text-anchor="end">用户名: {{ config.username if config else '' }}</text>
 </svg>


### PR DESCRIPTION
## Summary
- Beautified `/admin/users` with Tailwind styling and clearer sections for invite codes and site settings.
- Replaced old NodeSeek config with site URL, username, and copyright fields; updated templates and SVG display.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f54de5c5c832aa05afb4d5add67c0