### PR TITLE
Refine IP display and SVG card

### DIFF
--- a/static/css/view_svg.css
+++ b/static/css/view_svg.css
@@ -20,14 +20,14 @@
   color: #4afc90;
 }
 
-.vps-info-list {
+.vps-info-grid {
   display: grid;
-  grid-template-columns: max-content 1fr;
-  gap: 8px 16px;
+  grid-template-columns: max-content max-content 1fr;
+  column-gap: 8px;
+  row-gap: 8px;
 }
-.vps-info-list dt {
+.vps-info-grid .label {
   font-weight: bold;
-  text-align: right;
 }
 
 .vps-footer {

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -38,17 +38,18 @@
 <div class="card-container">
     <div class="svg-card">
         <h2 class="text-center text-cyan-300 text-xl mb-4 font-bold">{{ vps.name }}</h2>
-        <dl class="vps-info-list">
-            <dt>商家：</dt><dd>{{ vps.vendor_name or '-' }}</dd>
-            <dt>配置：</dt><dd>{{ specs.cpu }} / {{ specs.memory }} / {{ specs.storage }}</dd>
-            <dt>月流量：</dt><dd>{{ vps.traffic_limit or '-' }}</dd>
-            <dt>IP 地址：</dt><dd>{{ ip_info.flag }} {{ ip_info.ip_display }} (<span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span>)</dd>
-            <dt>到期时间：</dt><dd>{{ data.cycle_end.strftime('%Y/%m/%d') if data.cycle_end else '-' }}</dd>
-            <dt>续费金额：</dt><dd>{{ vps.renewal_price or '-' }} {{ vps.currency }}</dd>
-            <dt>剩余天数：</dt><dd>{{ data.remaining_days }} 天</dd>
-            <dt>剩余价值：</dt><dd>{{ data.remaining_value }} 元</dd>
-            <dt>描述说明：</dt><dd>{{ vps.description or '-' }}</dd>
-        </dl>
+        <div class="vps-info-grid">
+            <div class="label">商家</div><div>：</div><div>{{ vps.vendor_name or '-' }}</div>
+            <div class="label">配置</div><div>：</div><div>{{ specs.cpu }} / {{ specs.memory }} / {{ specs.storage }}</div>
+            <div class="label">月流量</div><div>：</div><div>{{ vps.traffic_limit or '-' }}</div>
+            <div class="label">IP 地址</div><div>：</div><div>{{ ip_info.flag }} {{ ip_info.ip_display }}</div>
+            <div class="label">在线状态</div><div>：</div><div><span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span></div>
+            <div class="label">到期时间</div><div>：</div><div>{{ data.cycle_end.strftime('%Y/%m/%d') if data.cycle_end else '-' }}</div>
+            <div class="label">续费金额</div><div>：</div><div>{{ vps.renewal_price or '-' }} {{ vps.currency }}</div>
+            <div class="label">剩余天数</div><div>：</div><div>{{ data.remaining_days }} 天</div>
+            <div class="label">剩余价值</div><div>：</div><div>{{ data.remaining_value }} 元</div>
+            <div class="label">描述说明</div><div>：</div><div>{{ vps.description or '-' }}</div>
+        </div>
         <div class="vps-footer">
             <p>更新时间: {{ today.strftime('%Y/%m/%d') }}</p>
             <p>用户名: {{ config.username if config and config.username else '' }}</p>

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -55,7 +55,8 @@
                 <div class="vps-row"><span>内存：</span><span>{{ specs.memory }}</span></div>
                 <div class="vps-row"><span>存储：</span><span>{{ specs.storage }}</span></div>
                 <div class="vps-row"><span>月流量：</span><span>{{ vps.traffic_limit or '-' }}</span></div>
-                <div class="vps-row"><span>IP 地址：</span><span>{{ ip_info.flag }} {{ ip_info.ip_display }} (<span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span>)</span></div>
+                <div class="vps-row"><span>IP 地址：</span><span>{{ ip_info.flag }} {{ ip_info.ip_display }}</span></div>
+                <div class="vps-row"><span>在线状态：</span><span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span></div>
                 <div class="vps-row"><span>续费金额：</span><span>{{ vps.renewal_price or '-' }} {{ vps.currency }}</span></div>
                 <div class="vps-row"><span>购买日期：</span><span>{{ vps.purchase_date.strftime('%Y-%m-%d') if vps.purchase_date and vps.status == 'active' else '-' }}</span></div>
                 <div class="vps-row"><span>续费周期：</span><span>{% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</span></div>

--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -30,11 +30,13 @@
 
   <text x="30" y="90" class="label">商家： {{ vps.vendor_name or '-' }}</text>
   <text x="30" y="115" class="label">配置： {{ specs.cpu }} / {{ specs.memory }} / {{ specs.storage }}</text>
-  <text x="30" y="140" class="label">续费金额： {{ vps.renewal_price }} {{ vps.currency }}</text>
-  <text x="30" y="165" class="label">续费周期： {% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</text>
-  <text x="30" y="190" class="label">购买日期： {{ vps.purchase_date.strftime('%Y/%m/%d') if vps.purchase_date else '-' }}</text>
-  <text x="30" y="215" class="label">剩余天数： {{ data.remaining_days }}</text>
-  <text x="30" y="240" class="label">剩余价值： {{ data.remaining_value }} 元</text>
+  <text x="30" y="140" class="label">IP 地址： {{ ip_info.flag }} {{ ip_info.ip_display }}</text>
+  <text x="30" y="165" class="label">在线状态： {{ ip_info.ping_status }}</text>
+  <text x="30" y="190" class="label">续费金额： {{ vps.renewal_price }} {{ vps.currency }}</text>
+  <text x="30" y="215" class="label">续费周期： {% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</text>
+  <text x="30" y="240" class="label">购买日期： {{ vps.purchase_date.strftime('%Y/%m/%d') if vps.purchase_date else '-' }}</text>
+  <text x="30" y="265" class="label">剩余天数： {{ data.remaining_days }}</text>
+  <text x="30" y="290" class="label">剩余价值： {{ data.remaining_value }} 元</text>
 
   <text x="610" y="400" class="footer" text-anchor="end">更新时间: {{ today.strftime('%Y/%m/%d') }}</text>
   <text x="610" y="420" class="footer" text-anchor="end">用户名: {{ config.username if config else '' }}</text>


### PR DESCRIPTION
## Summary
- separate IP address and ping status on VPS list and SVG view
- align SVG detail card with colon-centered grid layout
- improve IP flag detection and include IP info in generated SVGs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f59c9e748832a901ee1a36519145c