### PR TITLE
Improve mobile card layout

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -65,6 +65,7 @@
   font-family: 'Courier New', monospace;
   color: var(--font-color);
   cursor: pointer;
+  box-sizing: border-box;
 }
 
 .vps-card:hover {
@@ -139,4 +140,20 @@
 
 .vps-row span:last-child {
   color: var(--font-color);
+}
+
+@media (max-width: 768px) {
+  .card-container {
+    gap: 1rem;
+    padding: 1rem;
+  }
+  .vps-card {
+    width: calc(50% - 0.5rem);
+  }
+}
+
+@media (max-width: 480px) {
+  .vps-card {
+    width: 100%;
+  }
 }

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -2,6 +2,7 @@
 <html lang="zh">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ name }} - SVG 展示</title>
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -2,6 +2,7 @@
 <html lang="zh">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>VPS 列表</title>
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">


### PR DESCRIPTION
## Summary
- add viewport meta tags for responsive display
- limit card layout to 2 per row on small screens

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f61fbf630832aae14ce5737b03c95