### PR TITLE
Align footer info with remaining values

### DIFF
--- a/static/css/view_svg.css
+++ b/static/css/view_svg.css
@@ -30,11 +30,23 @@
   font-weight: bold;
 }
 
-.vps-footer {
+.vps-card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
   margin-top: 1.5rem;
-  text-align: right;
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.4);
+  padding-top: 1rem;
+  border-top: 1px dashed rgba(255, 255, 255, 0.2);
+}
+
+.vps-card-footer .left-info,
+.vps-card-footer .right-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-family: monospace;
+  font-size: 0.95rem;
+  color: #68f8bc;
 }
 
 .card-buttons {

--- a/static/images/vps_card.svg
+++ b/static/images/vps_card.svg
@@ -62,6 +62,6 @@
     <tspan x="30" dy="25">剩余价值： 72.04 元</tspan>
   </text>
 
-  <text x="30" y="250" class="footer">更新时间：2025/08/03</text>
-  <text x="30" y="270" class="footer">Noodseek ID：@Flanker</text>
+  <text x="370" y="180" class="footer" text-anchor="end">更新时间：2025/08/03</text>
+  <text x="370" y="205" class="footer" text-anchor="end">Noodseek ID：@Flanker</text>
 </svg>

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -48,13 +48,17 @@
             <div class="label">在线状态</div><div>：</div><div><span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span></div>
             <div class="label">到期时间</div><div>：</div><div>{{ data.cycle_end.strftime('%Y/%m/%d') if data.cycle_end else '-' }}</div>
             <div class="label">续费金额</div><div>：</div><div>{{ vps.renewal_price or '-' }} {{ vps.currency }}</div>
-            <div class="label">剩余天数</div><div>：</div><div>{{ data.remaining_days }} 天</div>
-            <div class="label">剩余价值</div><div>：</div><div>{{ data.remaining_value }} 元</div>
             <div class="label">描述说明</div><div>：</div><div>{{ vps.description or '-' }}</div>
         </div>
-        <div class="vps-footer">
-            <p>更新时间: {{ today.strftime('%Y/%m/%d') }}</p>
-            <p>用户名: {{ config.username if config and config.username else '' }}</p>
+        <div class="vps-card-footer">
+            <div class="left-info">
+                <div>剩余天数：{{ data.remaining_days }} 天</div>
+                <div>剩余价值：{{ data.remaining_value }} 元</div>
+            </div>
+            <div class="right-info">
+                <div>更新时间：{{ today.strftime('%Y/%m/%d') }}</div>
+                <div>用户名：{{ config.username if config and config.username else '' }}</div>
+            </div>
         </div>
         <div class="card-buttons">
             <a href="{{ url_for('vps_list') }}">返回列表</a>

--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -38,6 +38,6 @@
   <text x="30" y="265" class="label">剩余天数： {{ data.remaining_days }}</text>
   <text x="30" y="290" class="label">剩余价值： {{ data.remaining_value }} 元</text>
 
-  <text x="610" y="400" class="footer" text-anchor="end">更新时间: {{ today.strftime('%Y/%m/%d') }}</text>
-  <text x="610" y="420" class="footer" text-anchor="end">用户名: {{ config.username if config else '' }}</text>
+  <text x="610" y="265" class="footer" text-anchor="end">更新时间: {{ today.strftime('%Y/%m/%d') }}</text>
+  <text x="610" y="290" class="footer" text-anchor="end">用户名: {{ config.username if config and config.username else '' }}</text>
 </svg>


### PR DESCRIPTION
## Summary
- Align update/user info with remaining days/value in generated SVG and view page
- Introduce flex-based footer layout with left/right columns for remaining data and update metadata
- Update sample SVG card to reflect new layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f68d55264832aabee83d9ffe5e8e7