### PR TITLE
Align SVG footer and compress spacing

### DIFF
--- a/static/css/view_svg.css
+++ b/static/css/view_svg.css
@@ -33,20 +33,21 @@
 .vps-card-footer {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
-  margin-top: 1.5rem;
-  padding-top: 1rem;
-  border-top: 1px dashed rgba(255, 255, 255, 0.2);
+  align-items: flex-end;
+  margin-top: 1.2rem;
+  padding-top: 0.8rem;
+  border-top: 1px dashed rgba(255, 255, 255, 0.15);
+  font-family: monospace;
+  font-size: 0.95rem;
+  color: #68f8bc;
 }
 
 .vps-card-footer .left-info,
 .vps-card-footer .right-info {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  font-family: monospace;
-  font-size: 0.95rem;
-  color: #68f8bc;
+  gap: 0.3rem;
+  white-space: nowrap;
 }
 
 .card-buttons {

--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" width="640" height="480" style="min-width:500px;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 340" width="640" height="340" style="min-width:500px;">
   <style>
     .title {
       fill: #50d0ff;


### PR DESCRIPTION
## Summary
- Bottom-align info blocks in SVG card footer and lighten spacing
- Shrink SVG card height to reduce bottom whitespace

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f6aeba474832a8fa805545fe397c6