### PR TITLE
feat: optimize VPS card layout

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -41,10 +41,10 @@
 
 /* 卡片容器布局 */
 .card-container {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 2rem;
-  justify-content: center;
+  justify-items: center;
   align-items: stretch;
   padding: 2rem;
 }
@@ -54,8 +54,9 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  width: 360px;
-  height: 520px;
+  width: 100%;
+  min-height: 520px;
+  height: auto;
   padding: 1rem;
   background-color: var(--card-bg);
   border-radius: var(--border-radius);

--- a/static/css/responsive.css
+++ b/static/css/responsive.css
@@ -41,8 +41,8 @@ body {
   }
 
   .card-container {
-    flex-direction: column;
-    align-items: center;
+    display: grid;
+    grid-template-columns: 1fr;
     gap: 1rem;
     padding: 0 1rem;
   }


### PR DESCRIPTION
## Summary
- switch to CSS grid for VPS cards so up to four display per row
- allow cards to grow with content to prevent overflow when titles wrap
- adjust responsive styles for grid layout on small screens

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f74f3909c832a918a9420bf9ac215