### PR TITLE
Reduce card container margins

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -43,10 +43,10 @@
 .card-container {
   display: flex;
   flex-wrap: wrap;
-  gap: 2rem;
-  justify-content: center;
+  gap: 1.5rem;
+  justify-content: space-between;
   align-items: stretch;
-  padding: 2rem;
+  padding: 1rem;
 }
 
 /* 单个卡片样式 */
@@ -146,7 +146,7 @@
 
 @media (max-width: 768px) {
   .card-container {
-    gap: 1rem;
-    padding: 1rem;
+    gap: 0.75rem;
+    padding: 0.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- tighten card grid spacing and align cards edge-to-edge for less side blank space
- reduce card spacing on small screens for compact layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f78e0a3dc832ab72cdc0a65618a4f