### PR TITLE
Sort VPS cards and fix IP country lookup

### DIFF
--- a/app.py
+++ b/app.py
@@ -356,6 +356,13 @@ def vps_list():
                 ip_info["ping_status"] = ping_ip(vps.ip_address)
                 ip_info["flag"] = ip_to_flag(vps.ip_address)
             vps_data.append((vps, data, specs, ip_info))
+        status_order = {"active": 0, "sold": 1, "inactive": 2}
+        vps_data.sort(
+            key=lambda item: (
+                status_order.get(item[0].status, 3),
+                -item[1]["remaining_value"],
+            )
+        )
     return render_template("vps.html", vps_data=vps_data)
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -167,14 +167,19 @@ def ip_to_flag(ip: str) -> str:
             return "🏳️"
         clean_ip = match.group(0)
 
-        # ipapi may return a JSON payload even for the /country/ endpoint
-        # (e.g. when rate limited).  To be more robust we explicitly request
-        # JSON and then look for a country code key.
-        resp = requests.get(f"https://ipapi.co/{clean_ip}/json/", timeout=5)
+        # ip-api returns JSON with a country code. Be tolerant of different
+        # response formats in case of alternative services or errors.
+        resp = requests.get(
+            f"http://ip-api.com/json/{clean_ip}?fields=countryCode", timeout=5
+        )
         code = None
         try:
             data = resp.json()
-            code = data.get("country_code") or data.get("country")
+            code = (
+                data.get("countryCode")
+                or data.get("country_code")
+                or data.get("country")
+            )
         except Exception:
             text = resp.text.strip().upper()
             if len(text) == 2 and text.isalpha():

--- a/tests/test_ip_to_flag.py
+++ b/tests/test_ip_to_flag.py
@@ -11,13 +11,13 @@ class DummyResponse:
 
 def test_ip_to_flag_handles_json_response(monkeypatch):
     def fake_get(url, timeout=5):
-        return DummyResponse({'country_code': 'US'})
+        return DummyResponse({'countryCode': 'US'})
     monkeypatch.setattr('app.utils.requests.get', fake_get)
     assert ip_to_flag('8.8.8.8') == '\U0001F1FA\U0001F1F8'
 
 
 def test_ip_to_flag_extracts_ipv4(monkeypatch):
     def fake_get(url, timeout=5):
-        return DummyResponse({'country_code': 'AU'})
+        return DummyResponse({'countryCode': 'AU'})
     monkeypatch.setattr('app.utils.requests.get', fake_get)
     assert ip_to_flag('some text 🇺🇳 1.2.3.4') == '\U0001F1E6\U0001F1FA'


### PR DESCRIPTION
## Summary
- sort VPS cards by status then remaining value
- use ip-api to look up IP country flags and update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7ff4c19c832ab1e5e4e9f95ed9df