### PR TITLE
fix: show emoji flags for IP addresses

### DIFF
--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -3,18 +3,18 @@
     .title {
       fill: #50d0ff;
       font-size: 22px;
-      font-family: 'JetBrains Mono', 'Courier New', monospace;
+      font-family: 'JetBrains Mono', 'Courier New', 'Noto Color Emoji', 'Segoe UI Emoji', 'Apple Color Emoji', monospace;
       font-weight: bold;
     }
     .label {
       fill: #4afc90;
       font-size: 16px;
-      font-family: 'JetBrains Mono', 'Courier New', monospace;
+      font-family: 'JetBrains Mono', 'Courier New', 'Noto Color Emoji', 'Segoe UI Emoji', 'Apple Color Emoji', monospace;
     }
     .footer {
       fill: #888;
       font-size: 14px;
-      font-family: 'JetBrains Mono', 'Courier New', monospace;
+      font-family: 'JetBrains Mono', 'Courier New', 'Noto Color Emoji', 'Segoe UI Emoji', 'Apple Color Emoji', monospace;
     }
     rect {
       fill: #0c0f17;


### PR DESCRIPTION
## Summary
- ensure flag emojis render by adding common emoji fonts to the SVG template

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f83600880832a9f4414420bc06cd4