### PR TITLE
Center footer content with GitHub icon

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,5 +1,8 @@
-<footer class="fixed bottom-0 left-0 w-full py-4 text-center bg-gray-900">
-  <a href="https://github.com/podcctv/vps-value-calculator" target="_blank">
-    <img src="https://img.shields.io/badge/github-vps_value_calculator-blue" alt="GitHub">
+<footer class="fixed bottom-0 left-0 w-full py-4 bg-gray-900 flex items-center justify-center space-x-2 text-white">
+  <span>© 2025 vcc.428048.xyz</span>
+  <a href="https://github.com/podcctv/vps-value-calculator" target="_blank" aria-label="GitHub repository">
+    <svg class="w-5 h-5 fill-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.726-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.758-1.333-1.758-1.09-.745.082-.729.082-.729 1.205.085 1.84 1.237 1.84 1.237 1.07 1.835 2.807 1.305 3.492.998.108-.775.418-1.305.76-1.605-2.665-.304-5.467-1.332-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.124-.303-.535-1.523.117-3.176 0 0 1.007-.322 3.3 1.23a11.5 11.5 0 013.003-.404c1.02.005 2.047.138 3.003.404 2.29-1.552 3.296-1.23 3.296-1.23.653 1.653.242 2.873.118 3.176.77.84 1.233 1.91 1.233 3.22 0 4.61-2.807 5.624-5.48 5.92.43.37.823 1.096.823 2.21 0 1.596-.015 2.882-.015 3.273 0 .322.218.694.825.576C20.565 21.795 24 17.295 24 12 24 5.37 18.63 0 12 0z"/>
+    </svg>
   </a>
 </footer>


### PR DESCRIPTION
## Summary
- Center footer items and add © 2025 vcc.428048.xyz text
- Replace badge with GitHub SVG icon

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f9548b79c832ab1bba5e5e51de9b3