### PR TITLE
Center card list and cap at four per row

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -44,9 +44,11 @@
   display: flex;
   flex-wrap: wrap;
   gap: 1.5rem;
-  justify-content: space-between;
+  justify-content: center;
   align-items: stretch;
   padding: 1rem 0;
+  max-width: 1112px;
+  margin: 0 auto;
 }
 
 /* 单个卡片样式 */


### PR DESCRIPTION
## Summary
- Center card grid display and constrain container width so only four cards render per row

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f99f51a54832ab3492a90e72aca9f