### PR TITLE
fix: adjust VPS card layout

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -41,14 +41,14 @@
 
 /* 卡片容器布局 */
 .card-container {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 1.5rem;
-  justify-content: center;
   align-items: stretch;
-  padding: 1rem 0;
-  max-width: 1112px;
+  padding: 1rem;
+  max-width: 1320px;
   margin: 0 auto;
+  box-sizing: border-box;
 }
 
 /* 单个卡片样式 */
@@ -56,7 +56,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  width: 260px;
+  width: 100%;
   max-width: 100%;
   min-height: 520px;
   height: auto;

--- a/static/css/responsive.css
+++ b/static/css/responsive.css
@@ -41,9 +41,9 @@ body {
   }
 
   .card-container {
+    grid-template-columns: 1fr;
     gap: 1rem;
     padding: 0 1rem;
-    justify-content: center;
   }
 
   .vps-card {


### PR DESCRIPTION
## Summary
- use CSS grid so VPS cards display up to four per row with side padding
- expand cards to full cell width for a less narrow layout
- ensure mobile view uses a single column grid

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f9b7c8760832a9d0bb9ea9fb2eb7e