### PR TITLE
Center and normalize VPS cards

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -39,14 +39,21 @@
   gap: 1rem;
 }
 
+/* 全局变量 */
+:root {
+  --card-width: 20ch; /* 默认卡片宽度，JS 会根据标题长度更新 */
+}
+
 /* 卡片容器布局 */
 .card-container {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(4, var(--card-width));
   gap: 1.5rem;
+  justify-content: center;
   align-items: stretch;
   padding: 1rem;
-  max-width: 1320px;
+  width: fit-content;
+  max-width: 100%;
   margin: 0 auto;
   box-sizing: border-box;
 }
@@ -56,8 +63,8 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  width: 100%;
-  max-width: 100%;
+  width: var(--card-width);
+  max-width: var(--card-width);
   min-height: 520px;
   height: auto;
   padding: 1rem;

--- a/static/css/responsive.css
+++ b/static/css/responsive.css
@@ -44,6 +44,7 @@ body {
     grid-template-columns: 1fr;
     gap: 1rem;
     padding: 0 1rem;
+    width: 100%;
   }
 
   .vps-card {
@@ -52,6 +53,8 @@ body {
     border-radius: 12px;
     font-size: 0.9rem;
     box-shadow: 0 0 12px rgba(0, 255, 128, 0.1);
+    width: 100%;
+    max-width: 100%;
   }
 
   .card-status-tag {

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -81,6 +81,18 @@
         });
     });
 
+    function adjustCardWidth() {
+        const titles = document.querySelectorAll('.vps-title');
+        if (!titles.length) return;
+        let maxLen = 0;
+        titles.forEach(t => {
+            maxLen = Math.max(maxLen, t.textContent.trim().length);
+        });
+        const width = Math.max(maxLen + 4, 20); // 额外留白
+        document.documentElement.style.setProperty('--card-width', `${width}ch`);
+    }
+    adjustCardWidth();
+
     function updatePingStatus() {
         document.querySelectorAll('.ping-status').forEach(el => {
             const ip = el.dataset.ip;


### PR DESCRIPTION
## Summary
- Center card grid and compute card width from VPS title length for consistent sizing
- Ensure mobile layout sets card width to full width
- Use JS to measure longest VPS title and update CSS variable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f9d09afcc832a979a1f889e4262bf