### PR TITLE
fix: center vps cards

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -46,8 +46,8 @@
 
 /* 卡片容器布局 */
 .card-container {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, var(--card-width));
+  display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
   justify-content: center;
   align-items: stretch;

--- a/static/css/responsive.css
+++ b/static/css/responsive.css
@@ -41,7 +41,7 @@ body {
   }
 
   .card-container {
-    grid-template-columns: 1fr;
+    flex-direction: column;
     gap: 1rem;
     padding: 0 1rem;
     width: 100%;


### PR DESCRIPTION
## Summary
- use flexbox for `.card-container` to keep cards centered with fewer entries
- adjust responsive styles for new flex layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f9fc03b28832a8ca89efdf9d14dcd