### PR TITLE
fix: ensure card width fits IP flag and address

### DIFF
--- a/templates/vps.html
+++ b/templates/vps.html
@@ -57,7 +57,7 @@
                 <div class="vps-row"><span>内存：</span><span>{{ specs.memory }}</span></div>
                 <div class="vps-row"><span>存储：</span><span>{{ specs.storage }}</span></div>
                 <div class="vps-row"><span>月流量：</span><span>{{ vps.traffic_limit or '-' }}</span></div>
-                <div class="vps-row"><span>IP 地址：</span><span>{{ ip_info.flag|twemoji }} {{ ip_info.ip_display }}</span></div>
+                <div class="vps-row"><span>IP 地址：</span><span class="ip-address">{{ ip_info.flag|twemoji }} {{ ip_info.ip_display }}</span></div>
                 <div class="vps-row"><span>在线状态：</span><span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span></div>
                 <div class="vps-row"><span>续费金额：</span><span>{{ vps.renewal_price or '-' }} {{ vps.currency }}</span></div>
                 <div class="vps-row"><span>购买日期：</span><span>{{ vps.purchase_date.strftime('%Y-%m-%d') if vps.purchase_date and vps.status == 'active' else '-' }}</span></div>
@@ -83,10 +83,14 @@
 
     function adjustCardWidth() {
         const titles = document.querySelectorAll('.vps-title');
+        const ips = document.querySelectorAll('.ip-address');
         if (!titles.length) return;
         let maxLen = 0;
         titles.forEach(t => {
             maxLen = Math.max(maxLen, t.textContent.trim().length);
+        });
+        ips.forEach(ip => {
+            maxLen = Math.max(maxLen, ip.textContent.trim().length + 5);
         });
         const width = Math.max(maxLen + 4, 20); // 额外留白
         document.documentElement.style.setProperty('--card-width', `${width}ch`);


### PR DESCRIPTION
## Summary
- include IP span class to measure width
- widen card layout based on IP length so flag + address fit

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fa1a77ce4832a9f1ffd66efd3effd