### PR TITLE
Prevent IP address wrapping

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -153,6 +153,15 @@
   color: var(--font-color);
 }
 
+.ip-address {
+  display: inline-block;
+  white-space: nowrap;
+  width: -moz-fit-content;
+  width: -webkit-fit-content;
+  width: fit-content;
+}
+
+
 @media (max-width: 768px) {
   .card-container {
     gap: 0.75rem;

--- a/static/css/view_svg.css
+++ b/static/css/view_svg.css
@@ -29,6 +29,14 @@
 .vps-info-grid .label {
   font-weight: bold;
 }
+.ip-address {
+  display: inline-block;
+  white-space: nowrap;
+  width: -moz-fit-content;
+  width: -webkit-fit-content;
+  width: fit-content;
+}
+
 
 .vps-card-footer {
   display: flex;

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -44,7 +44,7 @@
             <div class="label">商家</div><div>：</div><div>{{ vps.vendor_name or '-' }}</div>
             <div class="label">配置</div><div>：</div><div>{{ specs.cpu }} / {{ specs.memory }} / {{ specs.storage }}</div>
             <div class="label">月流量</div><div>：</div><div>{{ vps.traffic_limit or '-' }}</div>
-            <div class="label">IP 地址</div><div>：</div><div>{{ ip_info.flag|twemoji }} {{ ip_info.ip_display }}</div>
+            <div class="label">IP 地址</div><div>：</div><div class="ip-address">{{ ip_info.flag|twemoji }} {{ ip_info.ip_display }}</div>
             <div class="label">在线状态</div><div>：</div><div><span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span></div>
             <div class="label">到期时间</div><div>：</div><div>{{ data.cycle_end.strftime('%Y/%m/%d') if data.cycle_end else '-' }}</div>
             <div class="label">续费金额</div><div>：</div><div>{{ vps.renewal_price or '-' }} {{ vps.currency }}</div>


### PR DESCRIPTION
## Summary
- Avoid line breaks for IP addresses by adding a reusable `ip-address` style
- Update VPS detail template to use the new style

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fa41072d0832a89f2ad166531390f