### PR TITLE
fix emoji and layout issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from app.utils import (
     mask_ip,
     ping_ip,
     ip_to_flag,
+    twemoji_url,
 )
 
 app = Flask(__name__)
@@ -43,11 +44,7 @@ def twemoji_filter(emoji: str) -> str:
     )
 
 
-@app.template_filter("twemoji_url")
-def twemoji_url_filter(emoji: str) -> str:
-    """Return a Twemoji CDN URL for the given emoji."""
-    code_points = "-".join(f"{ord(c):x}" for c in emoji)
-    return f"{TWEMOJI_BASE}/{code_points}.svg"
+app.add_template_filter(twemoji_url, "twemoji_url")
 
 Base.metadata.create_all(bind=engine)
 

--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -155,10 +155,9 @@
 
 .ip-address {
   display: inline-block;
-  white-space: nowrap;
-  width: -moz-fit-content;
-  width: -webkit-fit-content;
-  width: fit-content;
+  max-width: 100%;
+  word-break: break-all;
+  white-space: normal;
 }
 
 

--- a/static/css/view_svg.css
+++ b/static/css/view_svg.css
@@ -31,10 +31,9 @@
 }
 .ip-address {
   display: inline-block;
-  white-space: nowrap;
-  width: -moz-fit-content;
-  width: -webkit-fit-content;
-  width: fit-content;
+  max-width: 100%;
+  word-break: break-all;
+  white-space: normal;
 }
 
 

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,4 +1,5 @@
-<footer class="fixed bottom-0 left-0 w-full py-4 bg-gray-900 flex items-center justify-center gap-2 text-white text-center">
+<div class="h-16"></div>
+<footer class="fixed bottom-0 left-0 w-full h-16 py-4 bg-gray-900 flex items-center justify-center gap-2 text-white text-center">
   <span>          © 2025 vcc.428048.xyz</span>
   <a href="https://github.com/podcctv/vps-value-calculator" target="_blank" aria-label="GitHub repository">
     <img


### PR DESCRIPTION
## Summary
- inline flag emoji as data URIs so SVG cards render correctly when pasted elsewhere
- prevent long IP addresses from overflowing card layout
- add footer spacer to avoid overlap on scroll

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890095e75a8832ab2087ac40bd6b588