### PR TITLE
Adjust card layout and footer behavior

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -64,9 +64,9 @@
   display: flex;
   flex-direction: column;
   width: var(--card-width);
-  max-width: var(--card-width);
-  min-height: 520px;
+  max-width: 90vw;
   height: auto;
+  max-height: 100vh;
   padding: 1rem;
   background-color: var(--card-bg);
   border-radius: var(--border-radius);

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,6 +1,5 @@
-<div class="h-16"></div>
-<footer class="fixed bottom-0 left-0 w-full h-16 py-4 bg-gray-900 flex items-center justify-center gap-2 text-white text-center">
-  <span>          © 2025 vcc.428048.xyz</span>
+<footer class="w-full h-16 py-4 bg-gray-900 flex items-center justify-center gap-2 text-white text-center">
+  <span>© 2025 vcc.428048.xyz</span>
   <a href="https://github.com/podcctv/vps-value-calculator" target="_blank" aria-label="GitHub repository">
     <img
       src="https://img.shields.io/badge/github-vps_value_calculator-blue"

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -84,7 +84,8 @@
     function adjustCardWidth() {
         const vendors = document.querySelectorAll('.vendor-name');
         const ips = document.querySelectorAll('.ip-address');
-        if (!vendors.length && !ips.length) return;
+        const cards = document.querySelectorAll('.vps-card');
+        if (!cards.length) return;
         let maxLen = 0;
         vendors.forEach(v => {
             maxLen = Math.max(maxLen, v.textContent.trim().length);
@@ -92,9 +93,17 @@
         ips.forEach(ip => {
             maxLen = Math.max(maxLen, ip.textContent.trim().length + 5);
         });
-        const width = Math.max(maxLen + 4, 20); // 额外留白
+        let width = Math.max(maxLen + 4, 20); // 额外留白
         document.documentElement.style.setProperty('--card-width', `${width}ch`);
+        let maxHeight = Math.max(...Array.from(cards).map(card => card.scrollHeight));
+        while (maxHeight > window.innerHeight && width < 100) {
+            const ratio = maxHeight / window.innerHeight;
+            width = Math.min(width * ratio, 100);
+            document.documentElement.style.setProperty('--card-width', `${width}ch`);
+            maxHeight = Math.max(...Array.from(cards).map(card => card.scrollHeight));
+        }
     }
+    window.addEventListener('resize', adjustCardWidth);
     adjustCardWidth();
 
     function updatePingStatus() {


### PR DESCRIPTION
## Summary
- Dynamically size VPS cards to fit within the viewport
- Make footer part of normal flow so it appears after scrolling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68900e69421c832abe5c74055a1c78d1