### PR TITLE
feat: add for-sale status and pricing options

### DIFF
--- a/app.py
+++ b/app.py
@@ -268,6 +268,8 @@ def add_vps():
                 update_cycle=int(form.get("update_cycle") or 7),
                 dynamic_svg=bool(form.get("dynamic_svg")),
                 status=form.get("status"),
+                sale_percent=float(form.get("sale_percent") or 0.0),
+                sale_fixed=float(form.get("sale_fixed") or 0.0),
             )
             db.add(vps)
             db.commit()
@@ -313,6 +315,8 @@ def edit_vps(vps_id: int):
             vps.update_cycle = int(form.get("update_cycle") or 7)
             vps.dynamic_svg = bool(form.get("dynamic_svg"))
             vps.status = form.get("status")
+            vps.sale_percent = float(form.get("sale_percent") or 0.0)
+            vps.sale_fixed = float(form.get("sale_fixed") or 0.0)
             db.commit()
             config = db.query(SiteConfig).first()
             data = calculate_remaining(vps)
@@ -337,6 +341,8 @@ def edit_vps(vps_id: int):
             "dynamic_svg": vps.dynamic_svg,
             "status": vps.status,
             "update_cycle": vps.update_cycle,
+            "sale_percent": vps.sale_percent,
+            "sale_fixed": vps.sale_fixed,
         }
         return render_template("add_vps.html", vps_data=vps_data)
 
@@ -375,7 +381,7 @@ def vps_list():
                 ip_info["ping_status"] = ping_ip(vps.ip_address)
                 ip_info["flag"] = ip_to_flag(vps.ip_address)
             vps_data.append((vps, data, specs, ip_info))
-        status_order = {"active": 0, "sold": 1, "inactive": 2}
+        status_order = {"active": 0, "forsale": 1, "sold": 2, "inactive": 3}
         vps_data.sort(
             key=lambda item: (
                 status_order.get(item[0].status, 3),

--- a/app/db.py
+++ b/app/db.py
@@ -58,6 +58,8 @@ def _run_migrations():
             "dynamic_svg": "BOOLEAN DEFAULT 1",
             "status": "TEXT DEFAULT 'active'",
             "cycle_base_date": "DATE",
+            "sale_percent": "FLOAT DEFAULT 0.0",
+            "sale_fixed": "FLOAT DEFAULT 0.0",
         }
         for column, definition in optional_columns.items():
             if column not in columns:

--- a/app/models.py
+++ b/app/models.py
@@ -27,6 +27,8 @@ class VPS(Base):
     update_cycle = Column(Integer, default=7)
     dynamic_svg = Column(Boolean, default=True)
     status = Column(String, default="active")
+    sale_percent = Column(Float, default=0.0)
+    sale_fixed = Column(Float, default=0.0)
 
 
 class User(Base):

--- a/app/utils.py
+++ b/app/utils.py
@@ -83,10 +83,14 @@ def calculate_remaining(vps):
             pass
     remaining_value = vps.renewal_price * rate * remaining_days / total_days
     total_value = vps.renewal_price * rate
+    sale_percent = getattr(vps, "sale_percent", 0.0) or 0.0
+    sale_fixed = getattr(vps, "sale_fixed", 0.0) or 0.0
+    final_price = remaining_value * (1 + sale_percent / 100) + sale_fixed
     return {
         "remaining_days": remaining_days,
         "remaining_value": round(remaining_value, 2),
         "total_value": round(total_value, 2),
+        "final_price": round(final_price, 2),
         "cycle_start": start,
         "cycle_end": end,
     }

--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -103,6 +103,11 @@
   color: #fff;
 }
 
+.vps-card.forsale .card-status-tag {
+  background: #facc15;
+  color: #000;
+}
+
 /* 状态标签 */
 .card-status-tag {
   position: absolute;

--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -66,7 +66,9 @@
         dynamic_svg: true,
         status: 'active',
         update_cycle: 1,
-        ip_address: ''
+        ip_address: '',
+        sale_percent: '0',
+        sale_fixed: '0'
       };
       const initial = { ...defaultData, ...(window.initialData || {}) };
       const [form, setForm] = useState(initial);
@@ -130,9 +132,32 @@
                   <label className="mb-1 text-cyan-200">VPS 状态</label>
                   <select name="status" value={form.status} onChange={handleChange} className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white focus:ring-2 focus:ring-cyan-400">
                     <option value="active">使用中</option>
+                    <option value="forsale">待出售</option>
                     <option value="sold">已转手</option>
                     <option value="inactive">已停用</option>
                   </select>
+                  {form.status === 'forsale' && (
+                    <>
+                      <div className="flex flex-col mt-4">
+                        <label className="mb-1 text-cyan-200">转让溢价 (%)</label>
+                        <select name="sale_percent" value={form.sale_percent} onChange={handleChange} className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white focus:ring-2 focus:ring-cyan-400">
+                          <option value="-50">-50%</option>
+                          <option value="-25">-25%</option>
+                          <option value="-10">-10%</option>
+                          <option value="-5">-5%</option>
+                          <option value="0">0%</option>
+                          <option value="5">+5%</option>
+                          <option value="10">+10%</option>
+                          <option value="25">+25%</option>
+                          <option value="50">+50%</option>
+                        </select>
+                      </div>
+                      <div className="flex flex-col mt-4">
+                        <label className="mb-1 text-cyan-200">固定溢价 (RMB)</label>
+                        <input type="number" step="0.01" name="sale_fixed" value={form.sale_fixed} onChange={handleChange} placeholder="如 10" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
+                      </div>
+                    </>
+                  )}
                 </div>
               </fieldset>
 

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -48,12 +48,20 @@
             <div class="label">在线状态</div><div>：</div><div><span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span></div>
             <div class="label">到期时间</div><div>：</div><div>{{ data.cycle_end.strftime('%Y/%m/%d') if data.cycle_end else '-' }}</div>
             <div class="label">续费金额</div><div>：</div><div>{{ vps.renewal_price or '-' }} {{ vps.currency }}</div>
+            {% if vps.status == 'forsale' %}
+            <div class="label">转让溢价</div><div>：</div><div>{{ vps.sale_percent }}%</div>
+            <div class="label">固定溢价</div><div>：</div><div>{{ vps.sale_fixed }} 元</div>
+            <div class="label">最终价格</div><div>：</div><div>{{ data.final_price }} 元</div>
+            {% endif %}
             <div class="label">描述说明</div><div>：</div><div>{{ vps.description or '-' }}</div>
         </div>
         <div class="vps-card-footer">
             <div class="left-info">
                 <div>剩余天数：{{ data.remaining_days }} 天</div>
                 <div>剩余价值：{{ data.remaining_value }} 元</div>
+                {% if vps.status == 'forsale' %}
+                <div>最终价格：{{ data.final_price }} 元</div>
+                {% endif %}
             </div>
             <div class="right-info">
                 <div>更新时间：{{ today.strftime('%Y/%m/%d') }}</div>

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -42,9 +42,11 @@
     {% if vps_data %}
     <div class="card-container">
         {% for vps, data, specs, ip_info in vps_data %}
-        <div class="vps-card relative {% if vps.status == 'sold' %}sold{% elif vps.status == 'inactive' %}inactive{% endif %}" data-href="{{ url_for('view_vps', name=vps.name) }}">
+        <div class="vps-card relative {% if vps.status == 'sold' %}sold{% elif vps.status == 'inactive' %}inactive{% elif vps.status == 'forsale' %}forsale{% endif %}" data-href="{{ url_for('view_vps', name=vps.name) }}">
             {% if vps.status == 'active' %}
             <span class="card-status-tag">在使用</span>
+            {% elif vps.status == 'forsale' %}
+            <span class="card-status-tag">待出售</span>
             {% elif vps.status == 'sold' %}
             <span class="card-status-tag">已转让</span>
             {% elif vps.status == 'inactive' %}
@@ -60,10 +62,15 @@
                 <div class="vps-row"><span>IP 地址：</span><span class="ip-address">{{ ip_info.flag|twemoji }} {{ ip_info.ip_display }}</span></div>
                 <div class="vps-row"><span>在线状态：</span><span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span></div>
                 <div class="vps-row"><span>续费金额：</span><span>{{ vps.renewal_price or '-' }} {{ vps.currency }}</span></div>
-                <div class="vps-row"><span>购买日期：</span><span>{{ vps.purchase_date.strftime('%Y-%m-%d') if vps.purchase_date and vps.status == 'active' else '-' }}</span></div>
+                <div class="vps-row"><span>购买日期：</span><span>{{ vps.purchase_date.strftime('%Y-%m-%d') if vps.purchase_date and (vps.status == 'active' or vps.status == 'forsale') else '-' }}</span></div>
                 <div class="vps-row"><span>续费周期：</span><span>{% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</span></div>
-                <div class="vps-row"><span>剩余天数：</span><span>{% if vps.status == 'active' %}{{ data.remaining_days }} 天{% else %}-{% endif %}</span></div>
-                <div class="vps-row"><span>剩余价值：</span><span>{% if vps.status == 'active' %}{{ data.remaining_value }} CNY{% else %}-{% endif %}</span></div>
+                <div class="vps-row"><span>剩余天数：</span><span>{% if vps.status == 'active' or vps.status == 'forsale' %}{{ data.remaining_days }} 天{% else %}-{% endif %}</span></div>
+                <div class="vps-row"><span>剩余价值：</span><span>{% if vps.status == 'active' or vps.status == 'forsale' %}{{ data.remaining_value }} CNY{% else %}-{% endif %}</span></div>
+                {% if vps.status == 'forsale' %}
+                <div class="vps-row"><span>转让溢价：</span><span>{{ vps.sale_percent }}%</span></div>
+                <div class="vps-row"><span>固定溢价：</span><span>{{ vps.sale_fixed }} 元</span></div>
+                <div class="vps-row"><span>最终价格：</span><span>{{ data.final_price }} CNY</span></div>
+                {% endif %}
                 <div class="vps-row"><span>描述说明：</span><span>{{ vps.description or '-' }}</span></div>
             </div>
         </div>

--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 340" width="640" height="340" style="min-width:500px;">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 {% if vps.status == 'forsale' %}420{% else %}340{% endif %}" width="640" height="{% if vps.status == 'forsale' %}420{% else %}340{% endif %}" style="min-width:500px;">
   <style>
     .title {
       fill: #50d0ff;
@@ -65,6 +65,23 @@
   <text x="120" y="290" class="label">：</text>
   <text x="140" y="290" class="label">{{ data.remaining_value }} 元</text>
 
+  {% if vps.status == 'forsale' %}
+  <text x="30" y="315" class="label">转让溢价</text>
+  <text x="120" y="315" class="label">：</text>
+  <text x="140" y="315" class="label">{{ vps.sale_percent }}%</text>
+
+  <text x="30" y="340" class="label">固定溢价</text>
+  <text x="120" y="340" class="label">：</text>
+  <text x="140" y="340" class="label">{{ vps.sale_fixed }} 元</text>
+
+  <text x="30" y="365" class="label">最终价格</text>
+  <text x="120" y="365" class="label">：</text>
+  <text x="140" y="365" class="label">{{ data.final_price }} 元</text>
+
+  <text x="610" y="390" class="footer" text-anchor="end">更新时间: {{ today.strftime('%Y/%m/%d') }}</text>
+  <text x="610" y="415" class="footer" text-anchor="end">NodeSeekID: {{ config.username if config and config.username else '' }}</text>
+  {% else %}
   <text x="610" y="265" class="footer" text-anchor="end">更新时间: {{ today.strftime('%Y/%m/%d') }}</text>
   <text x="610" y="290" class="footer" text-anchor="end">NodeSeekID: {{ config.username if config and config.username else '' }}</text>
+  {% endif %}
 </svg>


### PR DESCRIPTION
## Summary
- add `forsale` VPS status with yellow card tag
- allow specifying percent/fixed sale premiums and compute final price
- render sale data and final price in SVG output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689014dde7ac832a8c94cc1cff905970