### PR TITLE
Align renewal info with metadata on sold SVG

### DIFF
--- a/static/images/vps_card.svg
+++ b/static/images/vps_card.svg
@@ -53,15 +53,15 @@
 
   <text x="30" y="40" class="title">demo</text>
 
-  <text x="30" y="80" class="label">
-    <tspan x="30" dy="0">商家： -</tspan>
-    <tspan x="30" dy="25">配置： - / - / -</tspan>
-    <tspan x="30" dy="25">续费周期： 每月</tspan>
-    <tspan x="30" dy="25">续费金额： 10.0 USD</tspan>
-    <tspan x="30" dy="25">剩余天数： 31</tspan>
-    <tspan x="30" dy="25">剩余价值： 72.04 元</tspan>
-  </text>
+  <text x="30" y="80" class="label">商家： -</text>
+  <text x="30" y="105" class="label">配置： - / - / -</text>
 
-  <text x="370" y="180" class="footer" text-anchor="end">更新时间：2025/08/03</text>
-  <text x="370" y="205" class="footer" text-anchor="end">Noodseek ID：@Flanker</text>
+  <text x="30" y="130" class="label">续费金额： 10.0 USD</text>
+  <text x="220" y="130" class="label">更新时间：2025/08/03</text>
+
+  <text x="30" y="155" class="label">续费周期： 每月</text>
+  <text x="220" y="155" class="label">NodeSeekID：@Flanker</text>
+
+  <text x="30" y="180" class="label">剩余天数： 31</text>
+  <text x="30" y="205" class="label">剩余价值： 72.04 元</text>
 </svg>

--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -60,11 +60,17 @@
   <text x="120" y="165" class="label">：</text>
   <text x="140" y="165" class="label">{{ vps.renewal_price }} {{ vps.currency }}</text>
 
+  <text x="360" y="165" class="label">更新时间</text>
+  <text x="450" y="165" class="label">：</text>
+  <text x="470" y="165" class="label">{{ today.strftime('%Y/%m/%d') }}</text>
+
   <text x="30" y="190" class="label">续费周期</text>
   <text x="120" y="190" class="label">：</text>
   <text x="140" y="190" class="label">{% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</text>
-  <text x="610" y="265" class="footer" text-anchor="end">更新时间: {{ today.strftime('%Y/%m/%d') }}</text>
-  <text x="610" y="290" class="footer" text-anchor="end">NodeSeekID: {{ config.username if config and config.username else '' }}</text>
+
+  <text x="360" y="190" class="label">NodeSeekID</text>
+  <text x="450" y="190" class="label">：</text>
+  <text x="470" y="190" class="label">{{ config.username if config and config.username else '' }}</text>
   {% else %}
   <text x="30" y="165" class="label">在线状态</text>
   <text x="120" y="165" class="label">：</text>


### PR DESCRIPTION
## Summary
- Align renewal price and cycle with update time and NodeSeekID in sold/inactive SVG template
- Adjust sample VPS card to display renewal and metadata side-by-side

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689048329748832abbfa83f5b3f4f053