### PR TITLE
Adjust VPS list card container width

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -52,8 +52,8 @@
   justify-content: center;
   align-items: stretch;
   padding: 1rem;
-  width: 100%;
-  max-width: 100%;
+  width: 90%;
+  max-width: 90%;
   margin: 0 auto;
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- adjust VPS list card container to use 90% width for better layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68905dcbb3b4832abc894e9fb3087547