### PR TITLE
Set VPS cards to 90% size by default

### DIFF
--- a/templates/vps.html
+++ b/templates/vps.html
@@ -90,20 +90,12 @@
     });
 
     const cardWrapper = document.querySelector('.card-wrapper');
-    let scale = 0.9;
-    function applyScale() {
+    if (cardWrapper) {
+        const scale = 0.9;
         cardWrapper.style.transform = `scale(${scale})`;
         cardWrapper.style.transformOrigin = 'top left';
         cardWrapper.style.width = `${100 / scale}%`;
     }
-    applyScale();
-
-    cardWrapper.addEventListener('wheel', (e) => {
-        e.preventDefault();
-        const delta = e.deltaY > 0 ? -0.1 : 0.1;
-        scale = Math.min(Math.max(scale + delta, 0.9), 1);
-        applyScale();
-    });
 
     function getTextWidth(text, font) {
         const canvas = getTextWidth.canvas || (getTextWidth.canvas = document.createElement('canvas'));


### PR DESCRIPTION
## Summary
- default VPS card wrapper to 90% scale
- remove mouse wheel scaling on VPS card list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689069489920832a8c452cd1da0386e4