### PR TITLE
style: adjust vps card width

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -52,15 +52,16 @@
   justify-content: center;
   align-items: stretch;
   padding: 1rem;
-  width: 90%;
-  max-width: 90%;
+  width: 100%;
+  max-width: 100%;
   margin: 0 auto;
   box-sizing: border-box;
 }
 
 .card-wrapper {
-  transform-origin: top left;
-  width: 100%;
+  width: 90%;
+  max-width: 1600px;
+  margin: 0 auto;
 }
 
 /* 单个卡片样式 */

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -89,14 +89,6 @@
         });
     });
 
-    const cardWrapper = document.querySelector('.card-wrapper');
-    if (cardWrapper) {
-        const scale = 0.9;
-        cardWrapper.style.transform = `scale(${scale})`;
-        cardWrapper.style.transformOrigin = 'top left';
-        cardWrapper.style.width = `${100 / scale}%`;
-    }
-
     function getTextWidth(text, font) {
         const canvas = getTextWidth.canvas || (getTextWidth.canvas = document.createElement('canvas'));
         const context = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- adjust VPS card container to use CSS width instead of JavaScript scaling
- remove inline scaling logic for card wrapper

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68906b9f3aac832a8589fdabfaff2490