### PR TITLE
feat: enhance monitoring with TCP ping

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -155,7 +155,7 @@ _ping_cache = {}
 
 
 def ping_ip(ip: str) -> str:
-    """Ping IP with simple caching and return emoji status."""
+    """Ping IP or ``ip:port`` and return emoji status with simple caching."""
     import subprocess
     import time
     import platform
@@ -168,28 +168,36 @@ def ping_ip(ip: str) -> str:
         return cached[1]
 
     status = "🔴 离线"
-    ping_exec = shutil.which("ping")
-    if ping_exec:
-        system = platform.system().lower()
-        count_arg = "-n" if system.startswith("win") else "-c"
-        timeout_arg = "-w" if system.startswith("win") else "-W"
+    if ":" in ip:
+        host, port = ip.rsplit(":", 1)
         try:
-            res = subprocess.run(
-                [ping_exec, count_arg, "1", timeout_arg, "1", ip],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-            if res.returncode == 0:
-                status = "🟢 在线"
-        except Exception:
-            pass
-
-    if status == "🔴 离线":
-        try:
-            socket.create_connection((ip, 80), timeout=1).close()
+            socket.create_connection((host, int(port)), timeout=1).close()
             status = "🟢 在线"
         except Exception:
             pass
+    else:
+        ping_exec = shutil.which("ping")
+        if ping_exec:
+            system = platform.system().lower()
+            count_arg = "-n" if system.startswith("win") else "-c"
+            timeout_arg = "-w" if system.startswith("win") else "-W"
+            try:
+                res = subprocess.run(
+                    [ping_exec, count_arg, "1", timeout_arg, "1", ip],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                if res.returncode == 0:
+                    status = "🟢 在线"
+            except Exception:
+                pass
+
+        if status == "🔴 离线":
+            try:
+                socket.create_connection((ip, 80), timeout=1).close()
+                status = "🟢 在线"
+            except Exception:
+                pass
 
     _ping_cache[ip] = (now, status)
     return status

--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -264,8 +264,8 @@
                   <input name="traffic_limit" value={form.traffic_limit} onChange={handleChange} placeholder="如 3TB / 无限" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
                 </div>
                 <div className="flex flex-col mt-4">
-                  <label className="mb-1 text-cyan-200">IP 地址</label>
-                  <input name="ip_address" value={form.ip_address} onChange={handleChange} placeholder="如 1.2.3.4" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
+                  <label className="mb-1 text-cyan-200">IP 地址（可含端口）</label>
+                  <input name="ip_address" value={form.ip_address} onChange={handleChange} placeholder="如 1.2.3.4 或 1.2.3.4:8080" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
                 </div>
               </fieldset>
 

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -81,7 +81,7 @@
     function updatePingStatus() {
         document.querySelectorAll('.ping-status').forEach(el => {
             const ip = el.dataset.ip;
-            fetch(`/ping/${ip}`).then(r => r.text()).then(t => {
+            fetch(`/ping/${encodeURIComponent(ip)}`).then(r => r.text()).then(t => {
                 el.textContent = t;
             });
         });

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -131,7 +131,7 @@
     function updatePingStatus() {
         document.querySelectorAll('.ping-status').forEach(el => {
             const ip = el.dataset.ip;
-            fetch(`/ping/${ip}`).then(r => r.text()).then(t => {
+            fetch(`/ping/${encodeURIComponent(ip)}`).then(r => r.text()).then(t => {
                 el.textContent = t;
             });
         });

--- a/tests/test_ping_ip.py
+++ b/tests/test_ping_ip.py
@@ -1,0 +1,23 @@
+import socket
+
+from app.utils import _ping_cache, ping_ip
+
+
+def test_ping_ip_with_open_port():
+    _ping_cache.clear()
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    s.listen(1)
+    port = s.getsockname()[1]
+    try:
+        status = ping_ip(f"127.0.0.1:{port}")
+    finally:
+        s.close()
+    assert status == "🟢 在线"
+
+
+def test_ping_ip_with_closed_port():
+    _ping_cache.clear()
+    status = ping_ip("127.0.0.1:1")
+    assert status == "🔴 离线"
+


### PR DESCRIPTION
## Summary
- allow entering IP with optional port on configuration page
- use TCP ping when port provided and encode IPs in ping requests
- add tests covering ping logic for open and closed ports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689154b198e4832ab6052d50e1f07a50