### PR TITLE
Fix encoded SVG URL for copy link

### DIFF
--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -90,7 +90,10 @@
     setInterval(updatePingStatus, 60000);
 
     document.getElementById('copyLinkBtn').addEventListener('click', function () {
-        const rawUrl = encodeURI({{ svg_abs_url|tojson }});
+        const encodedUrl = {{ svg_abs_url|tojson }}
+            .split('/')
+            .map((seg, idx) => (idx < 3 ? seg : encodeURIComponent(seg)))
+            .join('/');
         const vendor = {{ (vps.vendor_name or '-')|tojson }};
         const machineName = {{ vps.name|tojson }};
         const status = {{ vps.status|tojson }};
@@ -164,7 +167,7 @@
         }
 
         lines.push('');
-        lines.push(`![image](${rawUrl})`);
+        lines.push(`![image](${encodedUrl})`);
 
         const text = lines.join('\n');
 


### PR DESCRIPTION
## Summary
- encode SVG URLs in copy button to escape special characters like `#`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891569d5800832aaf361a8a88d25871