### PR TITLE
feat: improve sale premium input and layout

### DIFF
--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -151,35 +151,59 @@
                           <option value="给ROOT" />
                         </datalist>
                       </div>
-                      <div className="flex flex-col mt-4">
-                        <label className="mb-1 text-cyan-200">转让溢价 (%)</label>
-                        <select name="sale_percent" value={form.sale_percent} onChange={handleChange} className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white focus:ring-2 focus:ring-cyan-400">
-                          <option value="-50">-50%</option>
-                          <option value="-25">-25%</option>
-                          <option value="-10">-10%</option>
-                          <option value="-5">-5%</option>
-                          <option value="0">0%</option>
-                          <option value="5">+5%</option>
-                          <option value="10">+10%</option>
-                          <option value="25">+25%</option>
-                          <option value="50">+50%</option>
-                        </select>
-                      </div>
-                      <div className="flex flex-col mt-4">
-                        <label className="mb-1 text-cyan-200">固定溢价 (RMB)</label>
-                        <input type="number" step="0.01" name="sale_fixed" value={form.sale_fixed} onChange={handleChange} placeholder="如 10" className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
-                      </div>
-                      <div className="flex flex-col mt-4">
-                        <label className="mb-1 text-cyan-200">Push 费用</label>
-                        <div className="flex gap-2">
-                          <input type="number" step="0.01" name="push_fee" value={form.push_fee} onChange={handleChange} placeholder="如 5" className="flex-1 bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none" />
-                          <select name="push_fee_currency" value={form.push_fee_currency} onChange={handleChange} className="bg-black border border-cyan-500 rounded-md px-2 text-white focus:ring-2 focus:ring-cyan-400">
-                            <option value="USD">USD</option>
-                            <option value="CNY">CNY</option>
-                            <option value="EUR">EUR</option>
-                            <option value="JPY">JPY</option>
-                            <option value="HKD">HKD</option>
-                          </select>
+                      <div className="mt-4 p-4 border border-cyan-500 rounded-md">
+                        <p className="text-sm text-gray-400 mb-2">
+                          溢价计算方式：最终价格 = （转让溢价 + 剩余价值 + PUSH费用 ） * （1+转让溢价%）+固定溢价
+                        </p>
+                        <div className="flex flex-col">
+                          <label className="mb-1 text-cyan-200">转让溢价 (%)</label>
+                          <input
+                            type="number"
+                            step="0.01"
+                            name="sale_percent"
+                            value={form.sale_percent}
+                            onChange={handleChange}
+                            placeholder="如 10"
+                            className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none"
+                          />
+                        </div>
+                        <div className="flex flex-col mt-4">
+                          <label className="mb-1 text-cyan-200">固定溢价 (RMB)</label>
+                          <input
+                            type="number"
+                            step="0.01"
+                            name="sale_fixed"
+                            value={form.sale_fixed}
+                            onChange={handleChange}
+                            placeholder="如 10"
+                            className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none"
+                          />
+                        </div>
+                        <div className="flex flex-col mt-4">
+                          <label className="mb-1 text-cyan-200">Push 费用</label>
+                          <div className="flex gap-2">
+                            <input
+                              type="number"
+                              step="0.01"
+                              name="push_fee"
+                              value={form.push_fee}
+                              onChange={handleChange}
+                              placeholder="如 5"
+                              className="flex-1 bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none"
+                            />
+                            <select
+                              name="push_fee_currency"
+                              value={form.push_fee_currency}
+                              onChange={handleChange}
+                              className="bg-black border border-cyan-500 rounded-md px-2 text-white focus:ring-2 focus:ring-cyan-400"
+                            >
+                              <option value="USD">USD</option>
+                              <option value="CNY">CNY</option>
+                              <option value="EUR">EUR</option>
+                              <option value="JPY">JPY</option>
+                              <option value="HKD">HKD</option>
+                            </select>
+                          </div>
                         </div>
                       </div>
                     </>


### PR DESCRIPTION
## Summary
- allow custom transfer premium percentage via number input
- group sale premium fields with calculation hint and allow negative premiums

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68915b3f76a8832a8ac1ef39d904853a