### PR TITLE
feat: improve sale premium UI and calculation

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -98,7 +98,7 @@ def calculate_remaining(vps):
         except Exception:
             pass
     push_fee_cny = push_fee * push_rate
-    final_price = remaining_value * (1 + sale_percent / 100) + sale_fixed + push_fee_cny
+    final_price = (remaining_value + push_fee_cny) * (1 + sale_percent / 100) + sale_fixed
     return {
         "remaining_days": remaining_days,
         "remaining_value": round(remaining_value, 2),

--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -5,3 +5,9 @@ input[type="date"] {
   padding: 0.5rem;
   border-radius: 6px;
 }
+
+.input-full-width {
+  width: 100%;
+  max-width: 600px;
+  box-sizing: border-box;
+}

--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -75,6 +75,7 @@
       };
       const initial = { ...defaultData, ...(window.initialData || {}) };
       const [form, setForm] = useState(initial);
+      const [pushRate, setPushRate] = useState(1);
       const isEdit = Boolean(window.initialData);
 
       const fetchRate = () => {
@@ -94,6 +95,21 @@
         }
       }, [form.currency, form.exchange_rate_source]);
 
+      useEffect(() => {
+        if (form.push_fee_currency === 'CNY') {
+          setPushRate(1);
+          return;
+        }
+        fetch(`https://open.er-api.com/v6/latest/${form.push_fee_currency}`)
+          .then(res => res.json())
+          .then(data => {
+            if (data && data.rates && data.rates.CNY) {
+              setPushRate(data.rates.CNY);
+            }
+          })
+          .catch(() => setPushRate(1));
+      }, [form.push_fee_currency]);
+
       // no cycle base or expiry date fields; cycle is computed server-side
 
       const handleChange = (e) => {
@@ -104,6 +120,24 @@
       const handleSubmit = () => {
         console.log(JSON.stringify(form));
       };
+
+      const salePercent = parseFloat(form.sale_percent) || 0;
+      const saleFixed = parseFloat(form.sale_fixed) || 0;
+      const pushFee = parseFloat(form.push_fee) || 0;
+      const renewalPrice = parseFloat(form.renewal_price) || 0;
+      const renewalDays = parseInt(form.renewal_days) || 0;
+      const exchangeRate = parseFloat(form.exchange_rate) || 1;
+      let remainingValue = 0;
+      if (form.purchase_date && renewalDays) {
+        const purchase = new Date(form.purchase_date);
+        const today = new Date();
+        const cycleEnd = new Date(purchase.getTime() + renewalDays * 24 * 3600 * 1000);
+        const remainingDays = Math.max(Math.ceil((cycleEnd - today) / (24 * 3600 * 1000)), 0);
+        remainingValue = renewalPrice * exchangeRate * remainingDays / renewalDays;
+      }
+      const pushFeeCny = pushFee * pushRate;
+      const transferPremium = (remainingValue + pushFeeCny) * salePercent / 100;
+      const finalPrice = remainingValue + pushFeeCny + transferPremium + saleFixed;
 
       return (
         <div className="container mx-auto px-4 py-8">
@@ -151,9 +185,9 @@
                           <option value="给ROOT" />
                         </datalist>
                       </div>
-                      <div className="mt-4 p-4 border border-cyan-500 rounded-md">
+                        <div className="mt-4 p-4 border border-cyan-500 rounded-md">
                         <p className="text-sm text-gray-400 mb-2">
-                          溢价计算方式：最终价格 = （转让溢价 + 剩余价值 + PUSH费用） * （1 + 转让溢价%） + 固定溢价
+                          溢价计算方式：最终价格 = （剩余价值 + PUSH费用） * （1 + 转让溢价%） + 固定溢价
                         </p>
                         <div className="mt-4 space-y-4 pl-4">
                           <div className="flex flex-col">
@@ -165,7 +199,7 @@
                               value={form.sale_percent}
                               onChange={handleChange}
                               placeholder="如 10"
-                              className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none"
+                              className="input-full-width bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none"
                             />
                           </div>
                           <div className="flex flex-col">
@@ -177,7 +211,7 @@
                               value={form.sale_fixed}
                               onChange={handleChange}
                               placeholder="如 10"
-                              className="w-full bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none"
+                              className="input-full-width bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none"
                             />
                           </div>
                           <div className="flex flex-col">
@@ -190,7 +224,7 @@
                                 value={form.push_fee}
                                 onChange={handleChange}
                                 placeholder="如 5"
-                                className="flex-1 bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none"
+                                className="input-full-width flex-1 bg-black border border-cyan-500 rounded-md px-4 py-2 text-white placeholder-gray-400 focus:ring-2 focus:ring-cyan-400 focus:outline-none"
                               />
                               <select
                                 name="push_fee_currency"
@@ -206,12 +240,39 @@
                               </select>
                             </div>
                           </div>
+                          </div>
+                          <div className="mt-6 overflow-auto">
+                            <table className="w-full text-sm text-center border border-cyan-500">
+                              <thead>
+                                <tr className="bg-black">
+                                  <th className="border border-cyan-500 px-2 py-1">转让溢价</th>
+                                  <th className="border border-cyan-500 px-2 py-1">剩余价值</th>
+                                  <th className="border border-cyan-500 px-2 py-1">Push费用</th>
+                                  <th className="border border-cyan-500 px-2 py-1">转让溢价%</th>
+                                  <th className="border border-cyan-500 px-2 py-1">固定溢价</th>
+                                  <th className="border border-cyan-500 px-2 py-1">最终价格</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                <tr>
+                                  <td className="border border-cyan-500 px-2 py-1">{transferPremium.toFixed(2)}</td>
+                                  <td className="border border-cyan-500 px-2 py-1">{remainingValue.toFixed(2)}</td>
+                                  <td className="border border-cyan-500 px-2 py-1">{pushFeeCny.toFixed(2)}</td>
+                                  <td className="border border-cyan-500 px-2 py-1">{salePercent}%</td>
+                                  <td className="border border-cyan-500 px-2 py-1">{saleFixed}</td>
+                                  <td className="border border-cyan-500 px-2 py-1">{finalPrice.toFixed(2)}</td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <p className="text-xs text-gray-400 mt-2 text-center">
+                              最终价格 = （{remainingValue.toFixed(2)} + {pushFeeCny.toFixed(2)}） * （1 + {salePercent}%） + {saleFixed} = {finalPrice.toFixed(2)}
+                            </p>
+                          </div>
                         </div>
-                      </div>
-                    </>
-                  )}
-                </div>
-              </fieldset>
+                      </>
+                    )}
+                  </div>
+                </fieldset>
 
               <fieldset className="border-b border-cyan-500 pb-4 mb-4">
                 <legend className="text-lg mb-2 text-cyan-300">续费信息</legend>

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -132,7 +132,8 @@
         lines.push('');
         lines.push('[欢迎大家试用VVC（vps-value-calculator）DOCKER部署动态剩余价值计算版](https://github.com/podcctv/vps-value-calculator)');
         lines.push('');
-        lines.push(`最终价格 = （[转让溢价]${transferPremiumCny} 元 + [剩余价值]${remainingValue}  + [PUSH费用]${pushFee}  ） * （1+[转让溢价]${transferPercentStr}）+[固定溢价]${fixedPremium}  = ${finalPrice} `);
+        lines.push(`转让溢价 = （[剩余价值]${remainingValue} + [PUSH费用]${pushFee}） * [转让溢价]${transferPercentStr} = ${transferPremiumCny} 元`);
+        lines.push(`最终价格 = （[剩余价值]${remainingValue} + [PUSH费用]${pushFee}） * （1+[转让溢价]${transferPercentStr}）+[固定溢价]${fixedPremium} = ${finalPrice}`);
         lines.push('');
 
         lines.push(`## 🟦 [${machineName}] ${vendor} - 出售信息\n`);


### PR DESCRIPTION
## Summary
- correct final price calculation to include push fee in markup
- show dynamic table and formula preview for transfer premium inputs
- add full-width styling utility for sale-related inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891617eea70832a93c1ca113895bfe9