### PR TITLE
style: beautify premium calculation section

### DIFF
--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -11,3 +11,57 @@ input[type="date"] {
   max-width: 600px;
   box-sizing: border-box;
 }
+
+/* Premium calculation table styling */
+.price-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  font-family: "JetBrains Mono", monospace;
+  text-align: center;
+  background-color: #121212;
+  color: #eee;
+  box-shadow: 0 0 10px rgba(0, 255, 255, 0.1);
+  overflow-x: auto;
+  display: block;
+}
+
+.price-table th,
+.price-table td {
+  padding: 12px 16px;
+  border: 1px solid #00c0ff;
+}
+
+.price-table th {
+  background-color: #001f2f;
+  color: #00d4ff;
+  font-weight: bold;
+}
+
+.price-table td.final {
+  font-weight: bold;
+  background-color: #003344;
+  color: #2ae39d;
+}
+
+.calculation-text {
+  text-align: center;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 14px;
+  color: #999;
+  margin-top: 0.5rem;
+  transition: all 0.3s ease;
+}
+
+.calculation-text .equal-sign {
+  color: #ffffff;
+  font-weight: bold;
+  margin: 0 4px;
+}
+
+@media (max-width: 640px) {
+  .price-table {
+    overflow-x: auto;
+    display: block;
+  }
+}

--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -242,31 +242,35 @@
                           </div>
                           </div>
                           <div className="mt-6 overflow-auto">
-                            <table className="w-full text-sm text-center border border-cyan-500">
+                            <table className="price-table">
                               <thead>
-                                <tr className="bg-black">
-                                  <th className="border border-cyan-500 px-2 py-1">转让溢价</th>
-                                  <th className="border border-cyan-500 px-2 py-1">剩余价值</th>
-                                  <th className="border border-cyan-500 px-2 py-1">Push费用</th>
-                                  <th className="border border-cyan-500 px-2 py-1">转让溢价%</th>
-                                  <th className="border border-cyan-500 px-2 py-1">固定溢价</th>
-                                  <th className="border border-cyan-500 px-2 py-1">最终价格</th>
+                                <tr>
+                                  <th>转让溢价</th>
+                                  <th>剩余价值</th>
+                                  <th>Push费用</th>
+                                  <th>转让溢价%</th>
+                                  <th>固定溢价</th>
+                                  <th>最终价格</th>
                                 </tr>
                               </thead>
                               <tbody>
                                 <tr>
-                                  <td className="border border-cyan-500 px-2 py-1">{transferPremium.toFixed(2)}</td>
-                                  <td className="border border-cyan-500 px-2 py-1">{remainingValue.toFixed(2)}</td>
-                                  <td className="border border-cyan-500 px-2 py-1">{pushFeeCny.toFixed(2)}</td>
-                                  <td className="border border-cyan-500 px-2 py-1">{salePercent}%</td>
-                                  <td className="border border-cyan-500 px-2 py-1">{saleFixed}</td>
-                                  <td className="border border-cyan-500 px-2 py-1">{finalPrice.toFixed(2)}</td>
+                                  <td>{transferPremium.toFixed(2)}</td>
+                                  <td>{remainingValue.toFixed(2)}</td>
+                                  <td>{pushFeeCny.toFixed(2)}</td>
+                                  <td>{salePercent}%</td>
+                                  <td>{saleFixed}</td>
+                                  <td className="final">{finalPrice.toFixed(2)}</td>
                                 </tr>
                               </tbody>
                             </table>
-                            <p className="text-xs text-gray-400 mt-2 text-center">
-                              最终价格 = （{remainingValue.toFixed(2)} + {pushFeeCny.toFixed(2)}） * （1 + {salePercent}%） + {saleFixed} = {finalPrice.toFixed(2)}
-                            </p>
+                            <div className="calculation-text">
+                              最终价格 <span className="equal-sign">=</span> ({remainingValue.toFixed(2)} + {pushFeeCny.toFixed(2)})
+                              <span className="equal-sign">*</span> (1 + {salePercent}%)
+                              <span className="equal-sign">+</span> {saleFixed}
+                              <span className="equal-sign">=</span>
+                              <strong style={{ color: '#2ae39d' }}>{finalPrice.toFixed(2)}</strong>
+                            </div>
                           </div>
                         </div>
                       </>


### PR DESCRIPTION
## Summary
- add custom CSS and markup to style premium calculation table
- enhance formula readability with highlighted final price

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689164b484d8832aa5cfe1f4213ac440