### PR TITLE
Fix premium calc layout and sign handling

### DIFF
--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -14,16 +14,13 @@ input[type="date"] {
 
 /* Premium calculation table styling */
 .price-table {
-  width: 100%;
   border-collapse: collapse;
-  margin-top: 1rem;
+  margin: 1rem auto 0;
   font-family: "JetBrains Mono", monospace;
   text-align: center;
   background-color: #121212;
   color: #eee;
   box-shadow: 0 0 10px rgba(0, 255, 255, 0.1);
-  overflow-x: auto;
-  display: block;
 }
 
 .price-table th,

--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -133,12 +133,14 @@
         const purchase = new Date(form.purchase_date);
         const today = new Date();
         const cycleEnd = new Date(purchase.getTime() + renewalDays * 24 * 3600 * 1000);
-        const remainingDays = Math.max(Math.ceil((cycleEnd - today) / (24 * 3600 * 1000)), 0);
+        const remainingDays = Math.max(Math.floor((cycleEnd - today) / (24 * 3600 * 1000)), 0);
         remainingValue = renewalPrice * exchangeRate * remainingDays / renewalDays;
       }
       const pushFeeCny = pushFee * pushRate;
       const transferPremium = (remainingValue + pushFeeCny) * salePercent / 100;
       const finalPrice = remainingValue + pushFeeCny + transferPremium + saleFixed;
+      const salePercentSign = salePercent >= 0 ? '+' : '-';
+      const saleFixedSign = saleFixed >= 0 ? '+' : '-';
 
       return (
         <div className="container mx-auto px-4 py-8">
@@ -242,7 +244,7 @@
                             </div>
                           </div>
                           </div>
-                          <div className="mt-6 overflow-auto">
+                          <div className="mt-6 overflow-auto flex flex-col items-center">
                             <table className="price-table">
                               <thead>
                                 <tr>
@@ -267,8 +269,8 @@
                             </table>
                             <div className="calculation-text">
                               最终价格 <span className="equal-sign">=</span> ({remainingValue.toFixed(2)} + {pushFeeCny.toFixed(2)})
-                              <span className="equal-sign">*</span> (1 + {salePercent}%)
-                              <span className="equal-sign">+</span> {saleFixed}
+                              <span className="equal-sign">*</span> (1 {salePercentSign} {Math.abs(salePercent)}%)
+                              <span className="equal-sign">{saleFixedSign}</span> {Math.abs(saleFixed)}
                               <span className="equal-sign">=</span>
                               <strong style={{ color: '#2ae39d' }}>{finalPrice.toFixed(2)}</strong>
                             </div>

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -126,6 +126,9 @@
         const transferPremiumCny = (
             (parseFloat(remainingValue) + parseFloat(pushFee)) * transferPercent / 100
         ).toFixed(2);
+        const percentSign = transferPercent >= 0 ? '+' : '-';
+        const fixedPremiumNum = parseFloat(fixedPremium) || 0;
+        const fixedSign = fixedPremiumNum >= 0 ? '+' : '-';
 
         const lines = [];
         lines.push(`[VVC一键发帖]${finalPrice} 出售${vendor}的${machineName} ${info['配置']} ${info['月流量']} 月流量 机器`);
@@ -133,7 +136,7 @@
         lines.push('[欢迎大家试用VVC（vps-value-calculator）DOCKER部署动态剩余价值计算版](https://github.com/podcctv/vps-value-calculator)');
         lines.push('');
         lines.push(`转让溢价 = （[剩余价值]${remainingValue} + [PUSH费用]${pushFee}） * [转让溢价]${transferPercentStr} = ${transferPremiumCny} 元`);
-        lines.push(`最终价格 = （[剩余价值]${remainingValue} + [PUSH费用]${pushFee}） * （1+[转让溢价]${transferPercentStr}）+[固定溢价]${fixedPremium} = ${finalPrice}`);
+        lines.push(`最终价格 = （[剩余价值]${remainingValue} + [PUSH费用]${pushFee}） * （1${percentSign}[转让溢价]${Math.abs(transferPercent)}%）${fixedSign}[固定溢价]${Math.abs(fixedPremiumNum)} = ${finalPrice}`);
         lines.push('');
 
         lines.push(`## 🟦 [${machineName}] ${vendor} - 出售信息\n`);


### PR DESCRIPTION
## Summary
- center premium calculation table for better layout
- handle negative premium values without extra plus sign
- align homepage final price calculation with backend

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689168713194832a88b05fb0da3d014e