### PR TITLE
feat: calculate final sale price using transfer premium

### DIFF
--- a/templates/vps.html
+++ b/templates/vps.html
@@ -69,7 +69,18 @@
                 <div class="vps-row"><span>剩余天数：</span><span>{% if vps.status == 'active' or vps.status == 'forsale' %}{{ data.remaining_days }} 天{% else %}-{% endif %}</span></div>
                 <div class="vps-row"><span>剩余价值：</span><span>{% if vps.status == 'active' or vps.status == 'forsale' %}{{ data.remaining_value }} CNY{% else %}-{% endif %}</span></div>
                 {% if vps.status == 'forsale' %}
-                <div class="vps-row"><span>最终价格：</span><span>{{ data.final_price }} CNY</span></div>
+                <div class="vps-row">
+                    <span>最终价格：</span>
+                    <span>
+                        {{
+                            (
+                                (data.remaining_value + data.push_fee_cny)
+                                * (1 + (vps.sale_percent or 0) / 100)
+                                + (vps.sale_fixed or 0)
+                            ) | round(2)
+                        }} CNY
+                    </span>
+                </div>
                 {% endif %}
                 <div class="vps-row"><span>描述说明：</span><span>{{ vps.description or '-' }}</span></div>
             </div>


### PR DESCRIPTION
## Summary
- compute for-sale VPS final price via remaining value, push fee, transfer premium, and fixed premium

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68916c8186b8832ab98426b8493d4c96