### PR TITLE
fix: unify VPS value calculation formula

### DIFF
--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -163,8 +163,9 @@
         remainingValue = renewalPrice * exchangeRate * remainingDays / totalDays;
       }
       const pushFeeCny = pushFee * pushRate;
-      const transferPremium = (remainingValue + pushFeeCny) * salePercent / 100;
-      const finalPrice = remainingValue + pushFeeCny + transferPremium + saleFixed;
+      const basePrice = remainingValue + pushFeeCny;
+      const finalPrice = basePrice * (1 + salePercent / 100) + saleFixed;
+      const transferPremium = basePrice * salePercent / 100;
       const salePercentSign = salePercent >= 0 ? '+' : '-';
       const saleFixedSign = saleFixed >= 0 ? '+' : '-';
 

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -71,15 +71,7 @@
                 {% if vps.status == 'forsale' %}
                 <div class="vps-row">
                     <span>最终价格：</span>
-                    <span>
-                        {{
-                            (
-                                (data.remaining_value + data.push_fee_cny)
-                                * (1 + (vps.sale_percent or 0) / 100)
-                                + (vps.sale_fixed or 0)
-                            ) | round(2)
-                        }} CNY
-                    </span>
+                    <span>{{ data.final_price }} CNY</span>
                 </div>
                 {% endif %}
                 <div class="vps-row"><span>描述说明：</span><span>{{ vps.description or '-' }}</span></div>


### PR DESCRIPTION
## Summary
- display backend-computed final price on VPS list page
- align edit form's price calculation with backend formula

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68916e4a6508832a9de9475734821e44