### PR TITLE
Fix remaining value calculation in VPS edit form

### DIFF
--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -143,6 +143,7 @@
       if (form.purchase_date && renewalDays) {
         const purchase = new Date(form.purchase_date);
         const today = new Date();
+        today.setHours(0, 0, 0, 0);
         let start = purchase;
         let end;
         if (monthsMap[renewalDays]) {


### PR DESCRIPTION
## Summary
- Normalize the current date to midnight when calculating remaining days on the edit form, preventing timezone offsets from inflating remaining value and final price.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689170f18848832a834847f93db8fc03