### PR TITLE
fix: correct cloudflare beacon script path

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -8,3 +8,4 @@
     />
   </a>
 </footer>
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "9448cdbde86d4cbd8de78250543cd333"}' crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- load Cloudflare Insights beacon from correct script URL

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891d6527524832a8897b86ab291f66c