### PR TITLE
perf: streamline asset loading

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -5,7 +5,7 @@
       src="https://img.shields.io/badge/github-vps_value_calculator-blue"
       alt="GitHub vps_value_calculator badge"
       class="h-5"
+      loading="lazy"
     />
   </a>
 </footer>
-<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "9448cdbde86d4cbd8de78250543cd333"}' crossorigin="anonymous"></script>

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>VPS 列表</title>
-<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/tailwind.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/crt.css') }}">


### PR DESCRIPTION
## Summary
- reduce font connection overhead by preconnecting to Google font domains
- drop Cloudflare Insights beacon and lazily load footer badge

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68934d6ea184832a992850ddceff4ce4