### PR TITLE
Add loading animation for VPS list page

### DIFF
--- a/static/css/loading.css
+++ b/static/css/loading.css
@@ -1,0 +1,26 @@
+#loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 9999;
+}
+
+.loader {
+    border: 8px solid #f3f3f3;
+    border-top: 8px solid #3498db;
+    border-radius: 50%;
+    width: 60px;
+    height: 60px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -12,8 +12,12 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/crt.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/cards.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
 <body class="min-h-screen font-mono">
+<div id="loading-overlay">
+    <div class="loader"></div>
+</div>
 <nav class="banner">
     <a href="{{ url_for('vps_list') }}" class="banner-home">
         <div class="banner-title">
@@ -131,7 +135,11 @@
         }
     }
     window.addEventListener('resize', adjustCardWidth);
-    window.addEventListener('load', adjustCardWidth);
+    window.addEventListener('load', () => {
+        adjustCardWidth();
+        const loader = document.getElementById('loading-overlay');
+        if (loader) loader.style.display = 'none';
+    });
 
     function updatePingStatus() {
         document.querySelectorAll('.ping-status').forEach(el => {


### PR DESCRIPTION
## Summary
- show a fullscreen loading spinner on the VPS list until content is ready
- hide the loader after initial scripts run

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68935716ee64832abc09eef6c1cf7cb4