### PR TITLE
Optimize VPS list loading by deferring IP lookups

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from flask import (
     url_for,
     session,
     Response,
+    jsonify,
 )
 import base64
 from werkzeug.security import generate_password_hash, check_password_hash
@@ -408,9 +409,6 @@ def vps_list():
             }
             if vps.ip_address:
                 ip_info["ip_display"] = mask_ip(vps.ip_address)
-                ip_info["ping_status"] = ping_ip(vps.ip_address)
-                ip_info["flag"] = ip_to_flag(vps.ip_address)
-                ip_info["isp"] = ip_to_isp(vps.ip_address)
             vps_data.append((vps, data, specs, ip_info))
         status_order = {"active": 0, "forsale": 1, "sold": 2, "inactive": 3}
         vps_data.sort(
@@ -425,6 +423,12 @@ def vps_list():
 @app.route("/ping/<path:ip>")
 def ping_status(ip: str):
     return ping_ip(ip)
+
+
+@app.route("/ipinfo/<path:ip>")
+def ip_info(ip: str):
+    """Return flag emoji and ISP name for ``ip``."""
+    return jsonify({"flag": ip_to_flag(ip), "isp": ip_to_isp(ip)})
 
 
 @app.route("/vps/<string:name>")
@@ -444,9 +448,6 @@ def view_vps(name: str):
         }
         if vps.ip_address:
             ip_info["ip_display"] = mask_ip(vps.ip_address)
-            ip_info["ping_status"] = ping_ip(vps.ip_address)
-            ip_info["flag"] = ip_to_flag(vps.ip_address)
-            ip_info["isp"] = ip_to_isp(vps.ip_address)
         generate_svg(vps, data, config)
     svg_url = url_for("static", filename=f"images/{name}.svg")
     if config and config.site_url:

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -44,8 +44,8 @@
             <div class="label">商家</div><div>：</div><div>{{ vps.vendor_name or '-' }}</div>
             <div class="label">配置</div><div>：</div><div>{{ specs.cpu }} / {{ specs.memory }} / {{ specs.storage }}</div>
             <div class="label">月流量</div><div>：</div><div>{{ vps.traffic_limit or '-' }}</div>
-            <div class="label">IP 地址</div><div>：</div><div class="ip-address">{{ ip_info.flag|twemoji }} {{ ip_info.ip_display }}</div>
-            <div class="label">ISP</div><div>：</div><div>{{ ip_info.isp }}</div>
+            <div class="label">IP 地址</div><div>：</div><div class="ip-address" data-ip="{{ vps.ip_address }}"><span class="ip-flag"></span> {{ ip_info.ip_display }}</div>
+            <div class="label">ISP</div><div>：</div><div class="isp-name" data-ip="{{ vps.ip_address }}">{{ ip_info.isp }}</div>
             <div class="label">在线状态</div><div>：</div><div><span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span></div>
             <div class="label">到期时间</div><div>：</div><div>{{ data.cycle_end.strftime('%Y/%m/%d') if data.cycle_end else '-' }}</div>
             <div class="label">续费金额</div><div>：</div><div>{{ vps.renewal_price or '-' }} {{ vps.currency }}</div>
@@ -78,6 +78,8 @@
     </div>
 </div>
 <script>
+    const TWEMOJI_BASE = 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg';
+
     function updatePingStatus() {
         document.querySelectorAll('.ping-status').forEach(el => {
             const ip = el.dataset.ip;
@@ -86,8 +88,27 @@
             });
         });
     }
+
+    function emojiToImg(emoji) {
+        const codePoints = Array.from(emoji).map(c => c.codePointAt(0).toString(16)).join('-');
+        return `<img src="${TWEMOJI_BASE}/${codePoints}.svg" alt="${emoji}" class="twemoji" style="display:inline-block;height:1em;width:1em;vertical-align:-0.1em;">`;
+    }
+
+    function updateIpInfo() {
+        document.querySelectorAll('.ip-address').forEach(el => {
+            const ip = el.dataset.ip;
+            fetch(`/ipinfo/${encodeURIComponent(ip)}`).then(r => r.json()).then(data => {
+                const flagEl = el.querySelector('.ip-flag');
+                if (flagEl) flagEl.innerHTML = emojiToImg(data.flag);
+                const ispEl = document.querySelector(`.isp-name[data-ip="${ip}"]`);
+                if (ispEl) ispEl.textContent = data.isp;
+            });
+        });
+    }
+
     updatePingStatus();
     setInterval(updatePingStatus, 60000);
+    updateIpInfo();
 
     document.getElementById('copyLinkBtn').addEventListener('click', function () {
         const encodedUrl = {{ svg_abs_url|tojson }}

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -62,12 +62,12 @@
             <h3 class="vps-title">{{ vps.name }}</h3>
             <div class="vps-content">
                 <div class="vps-row"><span>商家：</span><span class="vendor-name">{{ vps.vendor_name or '-' }}</span></div>
-                <div class="vps-row"><span>ISP：</span><span class="isp-name">{{ ip_info.isp }}</span></div>
+                <div class="vps-row"><span>ISP：</span><span class="isp-name" data-ip="{{ vps.ip_address }}">{{ ip_info.isp }}</span></div>
                 <div class="vps-row"><span>CPU：</span><span>{{ specs.cpu }}</span></div>
                 <div class="vps-row"><span>内存：</span><span>{{ specs.memory }}</span></div>
                 <div class="vps-row"><span>存储：</span><span>{{ specs.storage }}</span></div>
                 <div class="vps-row"><span>月流量：</span><span>{{ vps.traffic_limit or '-' }}</span></div>
-                <div class="vps-row"><span>IP 地址：</span><span class="ip-address">{{ ip_info.flag|twemoji }} {{ ip_info.ip_display }}</span></div>
+                <div class="vps-row"><span>IP 地址：</span><span class="ip-address" data-ip="{{ vps.ip_address }}"><span class="ip-flag"></span> {{ ip_info.ip_display }}</span></div>
                 <div class="vps-row"><span>在线状态：</span><span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span></div>
                 <div class="vps-row"><span>续费金额：</span><span>{{ vps.renewal_price or '-' }} {{ vps.currency }}</span></div>
                 <div class="vps-row"><span>购买日期：</span><span>{{ vps.purchase_date.strftime('%Y-%m-%d') if vps.purchase_date and (vps.status == 'active' or vps.status == 'forsale') else '-' }}</span></div>
@@ -92,6 +92,8 @@
 </div>
 
 <script>
+    const TWEMOJI_BASE = 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg';
+
     document.querySelectorAll('.vps-card').forEach(card => {
         card.addEventListener('click', () => {
             window.location.href = card.dataset.href;
@@ -149,8 +151,27 @@
             });
         });
     }
+
+    function emojiToImg(emoji) {
+        const codePoints = Array.from(emoji).map(c => c.codePointAt(0).toString(16)).join('-');
+        return `<img src="${TWEMOJI_BASE}/${codePoints}.svg" alt="${emoji}" class="twemoji" style="display:inline-block;height:1em;width:1em;vertical-align:-0.1em;">`;
+    }
+
+    function updateIpInfo() {
+        document.querySelectorAll('.ip-address').forEach(el => {
+            const ip = el.dataset.ip;
+            fetch(`/ipinfo/${encodeURIComponent(ip)}`).then(r => r.json()).then(data => {
+                const flagEl = el.querySelector('.ip-flag');
+                if (flagEl) flagEl.innerHTML = emojiToImg(data.flag);
+                const ispEl = document.querySelector(`.isp-name[data-ip="${ip}"]`);
+                if (ispEl) ispEl.textContent = data.isp;
+            });
+        });
+    }
+
     updatePingStatus();
     setInterval(updatePingStatus, 60000);
+    updateIpInfo();
 </script>
 {% include 'footer.html' %}
 


### PR DESCRIPTION
## Summary
- reduce blocking work when rendering `/vps` and `/vps/<name>` by removing synchronous IP lookups
- add `/ipinfo` endpoint and client-side fetches for flag and ISP
- render IP info asynchronously with Twemoji icons

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689359171bd4832aba17913a68cc1c81