### PR TITLE
Cache server status for 10 minutes

### DIFF
--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -44,9 +44,9 @@
             <div class="label">商家</div><div>：</div><div>{{ vps.vendor_name or '-' }}</div>
             <div class="label">配置</div><div>：</div><div>{{ specs.cpu }} / {{ specs.memory }} / {{ specs.storage }}</div>
             <div class="label">月流量</div><div>：</div><div>{{ vps.traffic_limit or '-' }}</div>
-            <div class="label">IP 地址</div><div>：</div><div class="ip-address" data-ip="{{ vps.ip_address }}"><span class="ip-flag"></span> {{ ip_info.ip_display }}</div>
-            <div class="label">ISP</div><div>：</div><div class="isp-name" data-ip="{{ vps.ip_address }}">{{ ip_info.isp }}</div>
-            <div class="label">在线状态</div><div>：</div><div><span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span></div>
+            <div class="label">IP 地址</div><div>：</div><div class="ip-address">{{ ip_info.flag|twemoji }} {{ ip_info.ip_display }}</div>
+            <div class="label">ISP</div><div>：</div><div class="isp-name">{{ ip_info.isp }}</div>
+            <div class="label">在线状态</div><div>：</div><div><span class="ping-status">{{ ip_info.ping_status }}</span></div>
             <div class="label">到期时间</div><div>：</div><div>{{ data.cycle_end.strftime('%Y/%m/%d') if data.cycle_end else '-' }}</div>
             <div class="label">续费金额</div><div>：</div><div>{{ vps.renewal_price or '-' }} {{ vps.currency }}</div>
             {% if vps.status == 'forsale' %}
@@ -78,37 +78,7 @@
     </div>
 </div>
 <script>
-    const TWEMOJI_BASE = 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg';
 
-    function updatePingStatus() {
-        document.querySelectorAll('.ping-status').forEach(el => {
-            const ip = el.dataset.ip;
-            fetch(`/ping/${encodeURIComponent(ip)}`).then(r => r.text()).then(t => {
-                el.textContent = t;
-            });
-        });
-    }
-
-    function emojiToImg(emoji) {
-        const codePoints = Array.from(emoji).map(c => c.codePointAt(0).toString(16)).join('-');
-        return `<img src="${TWEMOJI_BASE}/${codePoints}.svg" alt="${emoji}" class="twemoji" style="display:inline-block;height:1em;width:1em;vertical-align:-0.1em;">`;
-    }
-
-    function updateIpInfo() {
-        document.querySelectorAll('.ip-address').forEach(el => {
-            const ip = el.dataset.ip;
-            fetch(`/ipinfo/${encodeURIComponent(ip)}`).then(r => r.json()).then(data => {
-                const flagEl = el.querySelector('.ip-flag');
-                if (flagEl) flagEl.innerHTML = emojiToImg(data.flag);
-                const ispEl = document.querySelector(`.isp-name[data-ip="${ip}"]`);
-                if (ispEl) ispEl.textContent = data.isp;
-            });
-        });
-    }
-
-    updatePingStatus();
-    setInterval(updatePingStatus, 60000);
-    updateIpInfo();
 
     document.getElementById('copyLinkBtn').addEventListener('click', function () {
         const encodedUrl = {{ svg_abs_url|tojson }}

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -62,13 +62,13 @@
             <h3 class="vps-title">{{ vps.name }}</h3>
             <div class="vps-content">
                 <div class="vps-row"><span>商家：</span><span class="vendor-name">{{ vps.vendor_name or '-' }}</span></div>
-                <div class="vps-row"><span>ISP：</span><span class="isp-name" data-ip="{{ vps.ip_address }}">{{ ip_info.isp }}</span></div>
+    <div class="vps-row"><span>ISP：</span><span class="isp-name">{{ ip_info.isp }}</span></div>
                 <div class="vps-row"><span>CPU：</span><span>{{ specs.cpu }}</span></div>
                 <div class="vps-row"><span>内存：</span><span>{{ specs.memory }}</span></div>
                 <div class="vps-row"><span>存储：</span><span>{{ specs.storage }}</span></div>
                 <div class="vps-row"><span>月流量：</span><span>{{ vps.traffic_limit or '-' }}</span></div>
-                <div class="vps-row"><span>IP 地址：</span><span class="ip-address" data-ip="{{ vps.ip_address }}"><span class="ip-flag"></span> {{ ip_info.ip_display }}</span></div>
-                <div class="vps-row"><span>在线状态：</span><span class="ping-status" data-ip="{{ vps.ip_address }}">{{ ip_info.ping_status }}</span></div>
+    <div class="vps-row"><span>IP 地址：</span><span class="ip-address">{{ ip_info.flag|twemoji }} {{ ip_info.ip_display }}</span></div>
+    <div class="vps-row"><span>在线状态：</span><span class="ping-status">{{ ip_info.ping_status }}</span></div>
                 <div class="vps-row"><span>续费金额：</span><span>{{ vps.renewal_price or '-' }} {{ vps.currency }}</span></div>
                 <div class="vps-row"><span>购买日期：</span><span>{{ vps.purchase_date.strftime('%Y-%m-%d') if vps.purchase_date and (vps.status == 'active' or vps.status == 'forsale') else '-' }}</span></div>
                 <div class="vps-row"><span>续费周期：</span><span>{% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</span></div>
@@ -92,7 +92,6 @@
 </div>
 
 <script>
-    const TWEMOJI_BASE = 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg';
 
     document.querySelectorAll('.vps-card').forEach(card => {
         card.addEventListener('click', () => {
@@ -143,35 +142,6 @@
         if (loader) loader.style.display = 'none';
     });
 
-    function updatePingStatus() {
-        document.querySelectorAll('.ping-status').forEach(el => {
-            const ip = el.dataset.ip;
-            fetch(`/ping/${encodeURIComponent(ip)}`).then(r => r.text()).then(t => {
-                el.textContent = t;
-            });
-        });
-    }
-
-    function emojiToImg(emoji) {
-        const codePoints = Array.from(emoji).map(c => c.codePointAt(0).toString(16)).join('-');
-        return `<img src="${TWEMOJI_BASE}/${codePoints}.svg" alt="${emoji}" class="twemoji" style="display:inline-block;height:1em;width:1em;vertical-align:-0.1em;">`;
-    }
-
-    function updateIpInfo() {
-        document.querySelectorAll('.ip-address').forEach(el => {
-            const ip = el.dataset.ip;
-            fetch(`/ipinfo/${encodeURIComponent(ip)}`).then(r => r.json()).then(data => {
-                const flagEl = el.querySelector('.ip-flag');
-                if (flagEl) flagEl.innerHTML = emojiToImg(data.flag);
-                const ispEl = document.querySelector(`.isp-name[data-ip="${ip}"]`);
-                if (ispEl) ispEl.textContent = data.isp;
-            });
-        });
-    }
-
-    updatePingStatus();
-    setInterval(updatePingStatus, 60000);
-    updateIpInfo();
 </script>
 {% include 'footer.html' %}
 

--- a/tests/test_ip_to_flag.py
+++ b/tests/test_ip_to_flag.py
@@ -1,4 +1,4 @@
-from app.utils import ip_to_flag
+from app.utils import ip_to_flag, _flag_cache
 
 class DummyResponse:
     def __init__(self, data):
@@ -10,6 +10,7 @@ class DummyResponse:
 
 
 def test_ip_to_flag_handles_json_response(monkeypatch):
+    _flag_cache.clear()
     def fake_get(url, timeout=5):
         return DummyResponse({'countryCode': 'US'})
     monkeypatch.setattr('app.utils.requests.get', fake_get)
@@ -17,6 +18,7 @@ def test_ip_to_flag_handles_json_response(monkeypatch):
 
 
 def test_ip_to_flag_extracts_ipv4(monkeypatch):
+    _flag_cache.clear()
     def fake_get(url, timeout=5):
         return DummyResponse({'countryCode': 'AU'})
     monkeypatch.setattr('app.utils.requests.get', fake_get)

--- a/tests/test_ip_to_isp.py
+++ b/tests/test_ip_to_isp.py
@@ -1,4 +1,4 @@
-from app.utils import ip_to_isp
+from app.utils import ip_to_isp, _isp_cache
 
 class DummyResponse:
     def __init__(self, data):
@@ -9,12 +9,14 @@ class DummyResponse:
         return self._data
 
 def test_ip_to_isp_handles_json_response(monkeypatch):
+    _isp_cache.clear()
     def fake_get(url, timeout=5):
         return DummyResponse({'isp': 'ExampleISP'})
     monkeypatch.setattr('app.utils.requests.get', fake_get)
     assert ip_to_isp('8.8.8.8') == 'ExampleISP'
 
 def test_ip_to_isp_extracts_ipv4(monkeypatch):
+    _isp_cache.clear()
     def fake_get(url, timeout=5):
         return DummyResponse({'isp': 'AnotherISP'})
     monkeypatch.setattr('app.utils.requests.get', fake_get)


### PR DESCRIPTION
## Summary
- cache ping, flag, and ISP lookups for 10 minutes to reduce external requests
- periodically refresh IP information and render cached values in pages
- remove client-side polling and use server-provided status data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68935c371480832aae98ed17fd7b2d79