### PR TITLE
feat: add global loading overlay

### DIFF
--- a/static/css/loading.css
+++ b/static/css/loading.css
@@ -6,6 +6,7 @@
     height: 100%;
     background: rgba(0, 0, 0, 0.8);
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     z-index: 9999;
@@ -20,7 +21,25 @@
     animation: spin 1s linear infinite;
 }
 
+#loading-bar {
+    width: 80%;
+    max-width: 400px;
+    height: 10px;
+    background: #f3f3f3;
+    border-radius: 5px;
+    overflow: hidden;
+    margin-top: 20px;
+}
+
+#loading-bar .progress {
+    height: 100%;
+    width: 0;
+    background: #3498db;
+    transition: width 0.3s;
+}
+
 @keyframes spin {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
 }
+

--- a/static/js/loading.js
+++ b/static/js/loading.js
@@ -1,0 +1,39 @@
+(function () {
+    const loader = document.getElementById('loading-overlay');
+    const progressBar = document.querySelector('#loading-bar .progress');
+    if (!loader || !progressBar) return;
+
+    let width = 0;
+    let interval;
+
+    function startProgress() {
+        loader.style.display = 'flex';
+        width = 0;
+        progressBar.style.width = '0%';
+        clearInterval(interval);
+        interval = setInterval(() => {
+            width = Math.min(width + Math.random() * 20, 90);
+            progressBar.style.width = width + '%';
+        }, 200);
+    }
+
+    function stopProgress() {
+        clearInterval(interval);
+        progressBar.style.width = '100%';
+        setTimeout(() => {
+            loader.style.display = 'none';
+        }, 300);
+    }
+
+    startProgress();
+    window.addEventListener('load', stopProgress);
+    window.addEventListener('beforeunload', startProgress);
+
+    document.querySelectorAll('a').forEach(link => {
+        link.addEventListener('click', e => {
+            const href = link.getAttribute('href');
+            if (!href || href.startsWith('#') || link.target === '_blank') return;
+            startProgress();
+        });
+    });
+})();

--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -13,8 +13,10 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/forms.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/cards.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
 <body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono">
+  {% include 'loading_overlay.html' %}
   <nav class="banner">
     <a href="{{ url_for('vps_list') }}" class="banner-home">
       <div class="banner-title">

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -10,8 +10,10 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/crt.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/cards.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
 <body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono">
+{% include 'loading_overlay.html' %}
 <nav class="banner">
     <a href="{{ url_for('vps_list') }}" class="banner-home">
         <div class="banner-title">

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -9,3 +9,4 @@
     />
   </a>
 </footer>
+<script src="{{ url_for('static', filename='js/loading.js') }}"></script>

--- a/templates/loading_overlay.html
+++ b/templates/loading_overlay.html
@@ -1,0 +1,4 @@
+<div id="loading-overlay">
+    <div class="loader"></div>
+    <div id="loading-bar"><div class="progress"></div></div>
+</div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -6,8 +6,10 @@
     <title>登录</title>
         <link rel="stylesheet" href="{{ url_for('static', filename='css/tailwind.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
 <body>
+    {% include 'loading_overlay.html' %}
     <h1>登录</h1>
     <form method="post">
         <p><input name="username" placeholder="用户名"></p>

--- a/templates/manage_vps.html
+++ b/templates/manage_vps.html
@@ -10,8 +10,10 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/crt.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/cards.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
 <body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono">
+{% include 'loading_overlay.html' %}
 <nav class="banner">
     <a href="{{ url_for('vps_list') }}" class="banner-home">
         <div class="banner-title">

--- a/templates/register.html
+++ b/templates/register.html
@@ -6,8 +6,10 @@
     <title>注册</title>
         <link rel="stylesheet" href="{{ url_for('static', filename='css/tailwind.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
 <body>
+    {% include 'loading_overlay.html' %}
     <h1>注册</h1>
     <form method="post">
         <p><input name="username" placeholder="用户名"></p>

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -11,8 +11,10 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/cards.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/view_svg.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
 <body class="min-h-screen font-mono">
+{% include 'loading_overlay.html' %}
 <nav class="banner">
     <a href="{{ url_for('vps_list') }}" class="banner-home">
         <div class="banner-title">

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -15,9 +15,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
 <body class="min-h-screen font-mono">
-<div id="loading-overlay">
-    <div class="loader"></div>
-</div>
+{% include 'loading_overlay.html' %}
 <nav class="banner">
     <a href="{{ url_for('vps_list') }}" class="banner-home">
         <div class="banner-title">
@@ -136,11 +134,7 @@
         }
     }
     window.addEventListener('resize', adjustCardWidth);
-    window.addEventListener('load', () => {
-        adjustCardWidth();
-        const loader = document.getElementById('loading-overlay');
-        if (loader) loader.style.display = 'none';
-    });
+    window.addEventListener('load', adjustCardWidth);
 
 </script>
 {% include 'footer.html' %}


### PR DESCRIPTION
## Summary
- show an animated spinner and progress bar while pages load
- apply loader during navigation between pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893675803bc832a94f15247f2bacab0