### PR TITLE
Replace spinner with animated loading text

### DIFF
--- a/static/css/loading.css
+++ b/static/css/loading.css
@@ -4,42 +4,34 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(0, 0, 0, 0.8);
+    background: rgba(0, 0, 0, 0.9);
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     z-index: 9999;
+    color: #fff;
 }
 
-.loader {
-    border: 8px solid #f3f3f3;
-    border-top: 8px solid #3498db;
-    border-radius: 50%;
-    width: 60px;
-    height: 60px;
-    animation: spin 1s linear infinite;
+.loading-text {
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin-bottom: 20px;
 }
 
 #loading-bar {
     width: 80%;
     max-width: 400px;
     height: 10px;
-    background: #f3f3f3;
+    background: #fff;
     border-radius: 5px;
     overflow: hidden;
-    margin-top: 20px;
 }
 
 #loading-bar .progress {
     height: 100%;
     width: 0;
-    background: #3498db;
+    background: #000;
     transition: width 0.3s;
-}
-
-@keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
 }
 

--- a/static/js/loading.js
+++ b/static/js/loading.js
@@ -1,27 +1,39 @@
 (function () {
     const loader = document.getElementById('loading-overlay');
     const progressBar = document.querySelector('#loading-bar .progress');
+    const loadingText = document.getElementById('loading-text');
     if (!loader || !progressBar) return;
 
     let width = 0;
     let interval;
+    let dotsInterval;
 
     function startProgress() {
         loader.style.display = 'flex';
         width = 0;
         progressBar.style.width = '0%';
+        if (loadingText) loadingText.textContent = 'Loading';
         clearInterval(interval);
+        clearInterval(dotsInterval);
         interval = setInterval(() => {
             width = Math.min(width + Math.random() * 20, 90);
             progressBar.style.width = width + '%';
         }, 200);
+        let dots = 0;
+        dotsInterval = setInterval(() => {
+            if (!loadingText) return;
+            dots = (dots + 1) % 4;
+            loadingText.textContent = 'Loading' + '.'.repeat(dots);
+        }, 500);
     }
 
     function stopProgress() {
         clearInterval(interval);
+        clearInterval(dotsInterval);
         progressBar.style.width = '100%';
         setTimeout(() => {
             loader.style.display = 'none';
+            if (loadingText) loadingText.textContent = 'Loading';
         }, 300);
     }
 

--- a/templates/loading_overlay.html
+++ b/templates/loading_overlay.html
@@ -1,4 +1,4 @@
 <div id="loading-overlay">
-    <div class="loader"></div>
+    <div id="loading-text" class="loading-text">Loading</div>
     <div id="loading-bar"><div class="progress"></div></div>
 </div>


### PR DESCRIPTION
## Summary
- swap out spinning loader for a black-and-white “Loading” text with animated dots
- keep progress bar but restyle to monochrome

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689369463374832a865affe8ee89ca6b