### PR TITLE
Suppress commit log output in deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -26,11 +26,8 @@ else
 fi
 
 # Reset working tree to match remote
-git reset --hard origin/main
+git reset --hard -q origin/main
 git clean -fd
-
-# Display the current commit for clarity
-git log -1 --oneline
 
 # Stop existing containers
 docker compose down


### PR DESCRIPTION
## Summary
- run `git reset --hard -q` and drop the `git log` call so `deploy.sh` doesn't print commit details

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68936a7bc7c0832a9d992d7c577870c5