### PR TITLE
fix progress overlay duplication and sticky footer layout

### DIFF
--- a/static/js/loading.js
+++ b/static/js/loading.js
@@ -7,8 +7,11 @@
     var width = 0;
     var interval;
     var dotsInterval;
+    var isLoading = false;
 
     function startProgress() {
+        if (isLoading) return;
+        isLoading = true;
         loader.style.display = 'flex';
         width = 0;
         progressBar.style.width = '0%';
@@ -34,6 +37,7 @@
         setTimeout(function () {
             loader.style.display = 'none';
             if (loadingText) loadingText.textContent = 'Loading';
+            isLoading = false;
         }, 300);
     }
 

--- a/templates/add_vps.html
+++ b/templates/add_vps.html
@@ -15,7 +15,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
-<body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono">
+<body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono flex flex-col">
   {% include 'loading_overlay.html' %}
   <nav class="banner">
     <a href="{{ url_for('vps_list') }}" class="banner-home">

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
-<body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono">
+<body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono flex flex-col">
 {% include 'loading_overlay.html' %}
 <nav class="banner">
     <a href="{{ url_for('vps_list') }}" class="banner-home">

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,4 +1,4 @@
-<footer class="w-full h-16 py-4 bg-gray-900 flex items-center justify-center gap-2 text-white text-center">
+<footer class="mt-auto w-full h-16 py-4 bg-gray-900 flex items-center justify-center gap-2 text-white text-center">
   <span>© 2025 vcc.428048.xyz</span>
   <a href="https://github.com/podcctv/vps-value-calculator" target="_blank" aria-label="GitHub repository">
     <img

--- a/templates/login.html
+++ b/templates/login.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
-<body>
+<body class="min-h-screen flex flex-col">
     {% include 'loading_overlay.html' %}
     <h1>登录</h1>
     <form method="post">

--- a/templates/manage_vps.html
+++ b/templates/manage_vps.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
-<body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono">
+<body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono flex flex-col">
 {% include 'loading_overlay.html' %}
 <nav class="banner">
     <a href="{{ url_for('vps_list') }}" class="banner-home">

--- a/templates/register.html
+++ b/templates/register.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
-<body>
+<body class="min-h-screen flex flex-col">
     {% include 'loading_overlay.html' %}
     <h1>注册</h1>
     <form method="post">

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
-<body class="min-h-screen font-mono">
+<body class="min-h-screen font-mono flex flex-col">
 {% include 'loading_overlay.html' %}
 <nav class="banner">
     <a href="{{ url_for('vps_list') }}" class="banner-home">

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -14,7 +14,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
-<body class="min-h-screen font-mono">
+<body class="min-h-screen font-mono flex flex-col">
 {% include 'loading_overlay.html' %}
 <nav class="banner">
     <a href="{{ url_for('vps_list') }}" class="banner-home">


### PR DESCRIPTION
## Summary
- ensure loading overlay progress bar starts only once during navigation
- keep footer anchored to the bottom of viewport on short pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68936cf2753c832a8534894aded8e6a1