### PR TITLE
Fix duplicate loading progress bar

### DIFF
--- a/static/css/loading.css
+++ b/static/css/loading.css
@@ -5,7 +5,7 @@
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.95);
-    display: flex;
+    display: none;
     flex-direction: column;
     align-items: center;
     justify-content: center;

--- a/static/js/loading.js
+++ b/static/js/loading.js
@@ -30,19 +30,8 @@
         }, 500);
     }
 
-    function stopProgress() {
-        clearInterval(interval);
-        clearInterval(dotsInterval);
-        progressBar.style.width = '100%';
-        setTimeout(function () {
-            loader.style.display = 'none';
-            if (loadingText) loadingText.textContent = 'Loading';
-            isLoading = false;
-        }, 300);
-    }
-
-    startProgress();
-    window.addEventListener('load', stopProgress);
+    // Progress bar starts on navigation events only
+    // Removed automatic start on page load to prevent duplicate flashes
     window.addEventListener('beforeunload', startProgress);
 
     var links = document.querySelectorAll('a');


### PR DESCRIPTION
## Summary
- Hide loading overlay by default and only show during navigation
- Remove automatic progress bar start on page load to prevent double flashes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68936ef205f4832a8cd87d417205780c