### PR TITLE
Center form inputs and widen submit buttons

### DIFF
--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -6,6 +6,11 @@ input[type="date"] {
   border-radius: 6px;
 }
 
+input,
+textarea {
+  text-align: center;
+}
+
 .input-full-width {
   width: 100%;
   max-width: 600px;

--- a/templates/login.html
+++ b/templates/login.html
@@ -13,9 +13,9 @@
     {% include 'loading_overlay.html' %}
     <div class="flex-1 flex items-center justify-center">
         <form method="post" class="flex flex-col items-center space-y-4">
-            <input name="username" placeholder="用户名" class="w-64 px-3 py-2 border rounded" />
-            <input type="password" name="password" placeholder="密码" class="w-64 px-3 py-2 border rounded" />
-            <button type="submit" class="w-64 bg-blue-500 hover:bg-blue-600 text-white py-2 rounded">进入</button>
+            <input name="username" placeholder="用户名" class="w-64 px-3 py-2 border rounded text-center" />
+            <input type="password" name="password" placeholder="密码" class="w-64 px-3 py-2 border rounded text-center" />
+            <button type="submit" class="w-72 bg-blue-500 hover:bg-blue-600 text-white py-2 rounded">进入</button>
         </form>
     </div>
     {% include 'footer.html' %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -13,10 +13,10 @@
     {% include 'loading_overlay.html' %}
     <div class="flex-1 flex items-center justify-center">
         <form method="post" class="flex flex-col items-center space-y-4">
-            <input name="username" placeholder="用户名" class="w-64 px-3 py-2 border rounded" />
-            <input type="password" name="password" placeholder="密码" class="w-64 px-3 py-2 border rounded" />
-            <input name="invite_code" placeholder="邀请码" class="w-64 px-3 py-2 border rounded" />
-            <button type="submit" class="w-64 bg-green-500 hover:bg-green-600 text-white py-2 rounded">提交</button>
+            <input name="username" placeholder="用户名" class="w-64 px-3 py-2 border rounded text-center" />
+            <input type="password" name="password" placeholder="密码" class="w-64 px-3 py-2 border rounded text-center" />
+            <input name="invite_code" placeholder="邀请码" class="w-64 px-3 py-2 border rounded text-center" />
+            <button type="submit" class="w-72 bg-green-500 hover:bg-green-600 text-white py-2 rounded">提交</button>
         </form>
     </div>
     {% include 'footer.html' %}


### PR DESCRIPTION
## Summary
- Center text inside register and login form fields
- Widen submit buttons for better usability
- Center form inputs globally via CSS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893774704c8832aafe8d1e10a3dc8f7