### PR TITLE
Center auth forms and align background color

### DIFF
--- a/static/css/animated-bg.css
+++ b/static/css/animated-bg.css
@@ -4,7 +4,5 @@
   100% {background-position: 0% 50%;}
 }
 .animated-bg {
-  background: linear-gradient(-45deg, #ee7752, #e73c7e, #23a6d5, #23d5ab);
-  background-size: 400% 400%;
-  animation: gradient 15s ease infinite;
+  background: #0f111a;
 }

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,10 +12,10 @@
 <body class="min-h-screen flex flex-col animated-bg">
     {% include 'loading_overlay.html' %}
     <div class="flex-1 flex items-center justify-center">
-        <form method="post" class="flex flex-col items-center space-y-4">
-            <input name="username" placeholder="用户名" class="w-64 px-3 py-2 border rounded text-center" />
-            <input type="password" name="password" placeholder="密码" class="w-64 px-3 py-2 border rounded text-center" />
-            <button type="submit" class="w-72 bg-blue-500 hover:bg-blue-600 text-white py-2 rounded">进入</button>
+        <form method="post" class="w-full max-w-xs flex flex-col space-y-4">
+            <input name="username" placeholder="用户名" class="w-full px-3 py-2 border rounded text-center" />
+            <input type="password" name="password" placeholder="密码" class="w-full px-3 py-2 border rounded text-center" />
+            <button type="submit" class="w-full bg-blue-500 hover:bg-blue-600 text-white py-2 rounded">进入</button>
         </form>
     </div>
     {% include 'footer.html' %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -12,11 +12,11 @@
 <body class="min-h-screen flex flex-col animated-bg">
     {% include 'loading_overlay.html' %}
     <div class="flex-1 flex items-center justify-center">
-        <form method="post" class="flex flex-col items-center space-y-4">
-            <input name="username" placeholder="用户名" class="w-64 px-3 py-2 border rounded text-center" />
-            <input type="password" name="password" placeholder="密码" class="w-64 px-3 py-2 border rounded text-center" />
-            <input name="invite_code" placeholder="邀请码" class="w-64 px-3 py-2 border rounded text-center" />
-            <button type="submit" class="w-72 bg-green-500 hover:bg-green-600 text-white py-2 rounded">提交</button>
+        <form method="post" class="w-full max-w-xs flex flex-col space-y-4">
+            <input name="username" placeholder="用户名" class="w-full px-3 py-2 border rounded text-center" />
+            <input type="password" name="password" placeholder="密码" class="w-full px-3 py-2 border rounded text-center" />
+            <input name="invite_code" placeholder="邀请码" class="w-full px-3 py-2 border rounded text-center" />
+            <button type="submit" class="w-full bg-green-500 hover:bg-green-600 text-white py-2 rounded">提交</button>
         </form>
     </div>
     {% include 'footer.html' %}


### PR DESCRIPTION
## Summary
- center login and registration form fields
- darken auth pages to match main site background

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689378f6cd54832ab21ff1d6d2099b65