### PR TITLE
fix svg refresh and adjust auth forms

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,7 +154,7 @@ def refresh_images():
         config = db.query(SiteConfig).first()
         vps_list = db.query(VPS).all()
         for vps in vps_list:
-            if not vps.dynamic_svg:
+            if not vps.dynamic_svg or vps.status in ["sold", "inactive"]:
                 continue
             data = calculate_remaining(vps)
             generate_svg(vps, data, config)

--- a/app/utils.py
+++ b/app/utils.py
@@ -297,6 +297,10 @@ def ip_to_isp(ip: str) -> str:
 def generate_svg(vps, data, config=None):
     template = env.get_template("vps.svg")
     specs = parse_instance_config(vps.instance_config)
+    STATIC_DIR.mkdir(parents=True, exist_ok=True)
+    out_file = STATIC_DIR / f"{vps.name}.svg"
+    if vps.status in ["sold", "inactive"] and out_file.exists():
+        return out_file
     today = date.today()
     ip_raw = getattr(vps, "ip_address", "") or ""
     ip_info = {
@@ -313,7 +317,5 @@ def generate_svg(vps, data, config=None):
         config=config,
         ip_info=ip_info,
     )
-    STATIC_DIR.mkdir(parents=True, exist_ok=True)
-    out_file = STATIC_DIR / f"{vps.name}.svg"
     out_file.write_text(content, encoding="utf-8")
     return out_file

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,7 +12,7 @@
 <body class="min-h-screen flex flex-col animated-bg">
     {% include 'loading_overlay.html' %}
     <div class="flex-1 flex items-center justify-center">
-        <form method="post" class="w-full max-w-xs flex flex-col space-y-4">
+        <form method="post" class="w-80 flex flex-col space-y-4">
             <input name="username" placeholder="用户名" class="w-full px-3 py-2 border rounded text-center" />
             <input type="password" name="password" placeholder="密码" class="w-full px-3 py-2 border rounded text-center" />
             <button type="submit" class="w-full bg-blue-500 hover:bg-blue-600 text-white py-2 rounded">进入</button>

--- a/templates/register.html
+++ b/templates/register.html
@@ -12,7 +12,7 @@
 <body class="min-h-screen flex flex-col animated-bg">
     {% include 'loading_overlay.html' %}
     <div class="flex-1 flex items-center justify-center">
-        <form method="post" class="w-full max-w-xs flex flex-col space-y-4">
+        <form method="post" class="w-80 flex flex-col space-y-4">
             <input name="username" placeholder="用户名" class="w-full px-3 py-2 border rounded text-center" />
             <input type="password" name="password" placeholder="密码" class="w-full px-3 py-2 border rounded text-center" />
             <input name="invite_code" placeholder="邀请码" class="w-full px-3 py-2 border rounded text-center" />

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -66,7 +66,9 @@
                 <div class="vps-row"><span>存储：</span><span>{{ specs.storage }}</span></div>
                 <div class="vps-row"><span>月流量：</span><span>{{ vps.traffic_limit or '-' }}</span></div>
     <div class="vps-row"><span>IP 地址：</span><span class="ip-address">{{ ip_info.flag|twemoji }} {{ ip_info.ip_display }}</span></div>
+    {% if vps.status != 'sold' and vps.status != 'inactive' %}
     <div class="vps-row"><span>在线状态：</span><span class="ping-status">{{ ip_info.ping_status }}</span></div>
+    {% endif %}
                 <div class="vps-row"><span>续费金额：</span><span>{{ vps.renewal_price or '-' }} {{ vps.currency }}</span></div>
                 <div class="vps-row"><span>购买日期：</span><span>{{ vps.purchase_date.strftime('%Y-%m-%d') if vps.purchase_date and (vps.status == 'active' or vps.status == 'forsale') else '-' }}</span></div>
                 <div class="vps-row"><span>续费周期：</span><span>{% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</span></div>

--- a/templates/vps.svg
+++ b/templates/vps.svg
@@ -69,8 +69,8 @@
   <text x="140" y="190" class="label">{% if vps.renewal_days == 30 %}每月{% elif vps.renewal_days == 90 %}每季度{% elif vps.renewal_days == 365 %}每年{% elif vps.renewal_days == 1095 %}三年{% elif vps.renewal_days %}{{ vps.renewal_days }}天{% else %}-{% endif %}</text>
 
   <text x="360" y="190" class="label">NodeSeekID</text>
-  <text x="450" y="190" class="label">：</text>
-  <text x="470" y="190" class="label">{{ config.username if config and config.username else '' }}</text>
+  <text x="480" y="190" class="label">：</text>
+  <text x="500" y="190" class="label">{{ config.username if config and config.username else '' }}</text>
   {% else %}
   <text x="30" y="165" class="label">在线状态</text>
   <text x="120" y="165" class="label">：</text>


### PR DESCRIPTION
## Summary
- limit width on login/register forms
- fix NodeSeekID label overlap in svg
- stop refreshing svg for sold or inactive VPS and hide online status on card

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68937b235970832ab3afcf74952dd9f1