### PR TITLE
fix: left-align login and register inputs

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -13,8 +13,8 @@
     {% include 'loading_overlay.html' %}
     <div class="flex-1 flex items-center justify-center">
         <form method="post" class="w-80 flex flex-col space-y-4">
-            <input name="username" placeholder="用户名" class="w-full px-3 py-2 border rounded text-center" />
-            <input type="password" name="password" placeholder="密码" class="w-full px-3 py-2 border rounded text-center" />
+            <input name="username" placeholder="用户名" class="w-full px-3 py-2 border rounded text-left" />
+            <input type="password" name="password" placeholder="密码" class="w-full px-3 py-2 border rounded text-left" />
             <button type="submit" class="w-full bg-blue-500 hover:bg-blue-600 text-white py-2 rounded">进入</button>
         </form>
     </div>

--- a/templates/register.html
+++ b/templates/register.html
@@ -13,9 +13,9 @@
     {% include 'loading_overlay.html' %}
     <div class="flex-1 flex items-center justify-center">
         <form method="post" class="w-80 flex flex-col space-y-4">
-            <input name="username" placeholder="用户名" class="w-full px-3 py-2 border rounded text-center" />
-            <input type="password" name="password" placeholder="密码" class="w-full px-3 py-2 border rounded text-center" />
-            <input name="invite_code" placeholder="邀请码" class="w-full px-3 py-2 border rounded text-center" />
+            <input name="username" placeholder="用户名" class="w-full px-3 py-2 border rounded text-left" />
+            <input type="password" name="password" placeholder="密码" class="w-full px-3 py-2 border rounded text-left" />
+            <input name="invite_code" placeholder="邀请码" class="w-full px-3 py-2 border rounded text-left" />
             <button type="submit" class="w-full bg-green-500 hover:bg-green-600 text-white py-2 rounded">提交</button>
         </form>
     </div>


### PR DESCRIPTION
## Summary
- left-align text in login inputs
- left-align text in registration inputs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68937e953200832a928e41809cadec0c