### PR TITLE
Add network diagnostics and progress overlay controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,6 +26,8 @@ from app.utils import (
     parse_instance_config,
     mask_ip,
     ping_ip,
+    traceroute_ip,
+    run_speedtest,
     ip_to_flag,
     ip_to_isp,
     twemoji_url,
@@ -433,6 +435,18 @@ def vps_list():
 @app.route("/ping/<path:ip>")
 def ping_status(ip: str):
     return ping_ip(ip)
+
+
+@app.route("/traceroute/<path:ip>")
+def traceroute_status(ip: str):
+    """Return traceroute output for ``ip``."""
+    return traceroute_ip(ip)
+
+
+@app.route("/speedtest")
+def speedtest_view():
+    """Run a network speed test and return simplified results."""
+    return jsonify(run_speedtest())
 
 
 @app.route("/ipinfo/<path:ip>")

--- a/static/js/loading.js
+++ b/static/js/loading.js
@@ -9,13 +9,13 @@
     var dotsInterval;
     var isLoading = false;
 
-    function startProgress() {
+    function startProgress(message) {
         if (isLoading) return;
         isLoading = true;
         loader.style.display = 'flex';
         width = 0;
         progressBar.style.width = '0%';
-        if (loadingText) loadingText.textContent = 'Loading';
+        if (loadingText) loadingText.textContent = message || 'Loading';
         clearInterval(interval);
         clearInterval(dotsInterval);
         interval = setInterval(function () {
@@ -26,8 +26,19 @@
         dotsInterval = setInterval(function () {
             if (!loadingText) return;
             dots = (dots + 1) % 4;
-            loadingText.textContent = 'Loading' + new Array(dots + 1).join('.');
+            loadingText.textContent = (message || 'Loading') + new Array(dots + 1).join('.');
         }, 500);
+    }
+
+    function updateProgress(current, total, message) {
+        if (!isLoading) startProgress();
+        if (typeof total === 'number' && total > 0) {
+            width = Math.min(100, (current / total) * 100);
+            progressBar.style.width = width + '%';
+        }
+        if (message && loadingText) {
+            loadingText.textContent = message;
+        }
     }
 
     function hideProgress() {
@@ -44,9 +55,16 @@
         if (loadingText) loadingText.textContent = 'Loading';
     }
 
+    // Expose control helpers for manual updates
+    window.loadingOverlay = {
+        start: startProgress,
+        update: updateProgress,
+        done: hideProgress
+    };
+
     // Progress bar starts on navigation events only
     // Removed automatic start on page load to prevent duplicate flashes
-    window.addEventListener('beforeunload', startProgress);
+    window.addEventListener('beforeunload', function () { startProgress(); });
 
     window.addEventListener('pageshow', hideProgress);
 

--- a/tests/test_traceroute_speedtest.py
+++ b/tests/test_traceroute_speedtest.py
@@ -1,0 +1,38 @@
+import json
+import subprocess
+from unittest.mock import patch, MagicMock
+
+from app.utils import traceroute_ip, run_speedtest
+
+
+def test_traceroute_unavailable():
+    with patch('shutil.which', return_value=None):
+        assert traceroute_ip('1.1.1.1') == 'traceroute unavailable'
+
+
+def test_traceroute_timeout():
+    mock_run = MagicMock(side_effect=subprocess.TimeoutExpired(cmd='traceroute', timeout=1))
+    with patch('shutil.which', return_value='/usr/bin/traceroute'), \
+         patch('subprocess.run', mock_run):
+        assert traceroute_ip('1.1.1.1', timeout=1) == 'Traceroute timed out'
+
+
+def test_speedtest_not_installed():
+    with patch('shutil.which', return_value=None):
+        assert run_speedtest() == {'error': 'speedtest not installed'}
+
+
+def test_speedtest_parse():
+    sample = {
+        'download': {'bandwidth': 12500000},
+        'upload': {'bandwidth': 5000000},
+        'ping': {'latency': 20.123, 'jitter': 1.5},
+    }
+    mock_proc = MagicMock(returncode=0, stdout=json.dumps(sample), stderr='')
+    with patch('shutil.which', return_value='/usr/bin/speedtest'), \
+         patch('subprocess.run', return_value=mock_proc):
+        res = run_speedtest()
+        assert res['download_mbps'] == round(12500000*8/1_000_000, 2)
+        assert res['upload_mbps'] == round(5000000*8/1_000_000, 2)
+        assert res['ping_ms'] == round(20.123, 2)
+        assert res['jitter_ms'] == round(1.5, 2)


### PR DESCRIPTION
## Summary
- Expose a `loadingOverlay` helper to report real-time test progress on the loading screen
- Add traceroute and speedtest utilities with safer timeouts and friendlier JSON output
- Provide `/traceroute/<ip>` and `/speedtest` API endpoints
- Cover traceroute and speedtest helpers with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894b552208c832a8b5e837e13c5f1c0