### PR TITLE
Track user registration time at hour granularity

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from functools import wraps
 from sqlalchemy.orm import Session
 from apscheduler.schedulers.background import BackgroundScheduler
-from datetime import date
+from datetime import date, datetime
 from markupsafe import Markup
 
 from app.db import engine, Base
@@ -198,6 +198,7 @@ def register():
                 username=username,
                 password_hash=generate_password_hash(password),
                 is_admin=is_admin,
+                created_at=datetime.utcnow().replace(minute=0, second=0, microsecond=0),
             )
             db.add(user)
             db.commit()

--- a/app/db.py
+++ b/app/db.py
@@ -69,6 +69,18 @@ def _run_migrations():
                 with engine.begin() as conn:
                     conn.execute(text(f"ALTER TABLE vps ADD COLUMN {column} {definition}"))
 
+    # Ensure created_at exists in users table
+    if "users" in inspector.get_table_names():
+        columns = [col["name"] for col in inspector.get_columns("users")]
+        if "created_at" not in columns:
+            with engine.begin() as conn:
+                conn.execute(text("ALTER TABLE users ADD COLUMN created_at DATETIME"))
+                conn.execute(
+                    text(
+                        "UPDATE users SET created_at = DATETIME('now','start of hour') WHERE created_at IS NULL"
+                    )
+                )
+
     # Ensure new fields in site_config table are present
     if "site_config" in inspector.get_table_names():
         columns = [col["name"] for col in inspector.get_columns("site_config")]

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,5 @@
-from sqlalchemy import Column, Integer, String, Float, Date, Boolean
+from sqlalchemy import Column, Integer, String, Float, Date, Boolean, DateTime
+from datetime import datetime
 from .db import Base
 
 
@@ -41,6 +42,10 @@ class User(Base):
     username = Column(String, unique=True, index=True)
     password_hash = Column(String)
     is_admin = Column(Boolean, default=False)
+    created_at = Column(
+        DateTime,
+        default=lambda: datetime.utcnow().replace(minute=0, second=0, microsecond=0),
+    )
 
 
 class InviteCode(Base):

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -79,6 +79,7 @@
                     <th class="py-2 px-3">ID</th>
                     <th class="py-2 px-3">用户名</th>
                     <th class="py-2 px-3">管理员</th>
+                    <th class="py-2 px-3">注册时间</th>
                     <th class="py-2 px-3">操作</th>
                 </tr>
             </thead>
@@ -88,6 +89,7 @@
                     <td class="py-2 px-3">{{ user.id }}</td>
                     <td class="py-2 px-3">{{ user.username }}</td>
                     <td class="py-2 px-3">{{ '是' if user.is_admin else '否' }}</td>
+                    <td class="py-2 px-3">{{ user.created_at.strftime('%Y-%m-%d %I:%M %p') if user.created_at else '-' }}</td>
                     <td class="py-2 px-3 space-x-2">
                         <form method="post" class="inline">
                             <input type="hidden" name="user_id" value="{{ user.id }}">


### PR DESCRIPTION
## Summary
- record `created_at` timestamps for users rounded to the hour
- migrate existing databases and display registration time in the admin page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894ba8ce474832aadeb7858ed874b3f