### PR TITLE
feat: add probe loading tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -403,8 +403,10 @@ def delete_vps(vps_id: int):
 
 
 @app.route("/")
+@app.route("/probe")
 def index():
-    return redirect(url_for("vps_list"))
+    """Initial probe page that runs network diagnostics before showing the VPS list."""
+    return render_template("probe.html")
 
 
 @app.route("/vps")

--- a/static/css/loading.css
+++ b/static/css/loading.css
@@ -40,3 +40,13 @@
     transition: width 0.3s;
 }
 
+.loading-status {
+    margin-top: 20px;
+    font-size: 1rem;
+    text-align: left;
+}
+
+.loading-status div {
+    margin-top: 4px;
+}
+

--- a/static/js/probe.js
+++ b/static/js/probe.js
@@ -1,0 +1,73 @@
+(function(){
+    const STATUS_IDS = {
+        ping: 'ping-status',
+        traceroute: 'traceroute-status',
+        speedtest: 'speedtest-status'
+    };
+
+    function setStatus(id, text) {
+        const el = document.getElementById(id);
+        if (el) {
+            el.textContent = text;
+        }
+    }
+
+    async function run() {
+        const tests = [
+            {
+                id: 'ping',
+                label: 'Ping',
+                run: async () => {
+                    const res = await fetch('/ping/1.1.1.1');
+                    return await res.text();
+                }
+            },
+            {
+                id: 'traceroute',
+                label: 'Traceroute',
+                run: async () => {
+                    const res = await fetch('/traceroute/1.1.1.1');
+                    return await res.text();
+                }
+            },
+            {
+                id: 'speedtest',
+                label: 'SpeedTest',
+                run: async () => {
+                    const res = await fetch('/speedtest');
+                    return await res.json();
+                }
+            }
+        ];
+
+        loadingOverlay.start('运行网络测试');
+
+        for (let i = 0; i < tests.length; i++) {
+            const t = tests[i];
+            const statusId = STATUS_IDS[t.id];
+            setStatus(statusId, t.label + '：测试中...');
+            try {
+                const result = await t.run();
+                let text = t.label + '：完成';
+                if (t.id === 'speedtest') {
+                    if (result.download && result.upload) {
+                        text += ` (下行 ${result.download} Mbps / 上行 ${result.upload} Mbps)`;
+                    } else if (result.error) {
+                        text += ` (${result.error})`;
+                    }
+                } else if (t.id === 'ping') {
+                    text += ` (${result})`;
+                }
+                setStatus(statusId, text);
+            } catch (err) {
+                setStatus(statusId, t.label + '：失败');
+            }
+            loadingOverlay.update(i + 1, tests.length);
+        }
+
+        loadingOverlay.done();
+        window.location.href = '/vps';
+    }
+
+    window.addEventListener('DOMContentLoaded', run);
+})();

--- a/templates/loading_overlay.html
+++ b/templates/loading_overlay.html
@@ -1,4 +1,9 @@
 <div id="loading-overlay">
     <div id="loading-text" class="loading-text">Loading</div>
     <div id="loading-bar"><div class="progress"></div></div>
+    <div id="loading-status" class="loading-status">
+        <div id="ping-status"></div>
+        <div id="traceroute-status"></div>
+        <div id="speedtest-status"></div>
+    </div>
 </div>

--- a/templates/probe.html
+++ b/templates/probe.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>网络探测</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/tailwind.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/crt.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
+</head>
+<body class="min-h-screen font-mono flex flex-col">
+    {% include 'loading_overlay.html' %}
+    <script src="{{ url_for('static', filename='js/loading.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/probe.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- run ping, traceroute and speedtest during initial probe page
- show step-by-step status in loading overlay
- redirect to VPS list after diagnostics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894bb30547c832a856ba6743e01e568