### PR TITLE
Add probe progress display

### DIFF
--- a/app.py
+++ b/app.py
@@ -444,6 +444,12 @@ def traceroute_status(ip: str):
     return traceroute_ip(ip)
 
 
+@app.route("/probe/<path:ip>")
+def probe_view(ip: str):
+    """Render a simple probe page showing ping and traceroute results."""
+    return render_template("probe.html", ip=ip)
+
+
 @app.route("/speedtest")
 def speedtest_view():
     """Run a network speed test and return simplified results."""

--- a/static/js/loading.js
+++ b/static/js/loading.js
@@ -40,6 +40,7 @@
         }
         if (message) {
             currentMessage = message;
+            if (loadingText) loadingText.textContent = currentMessage;
         }
     }
 

--- a/static/js/probe.js
+++ b/static/js/probe.js
@@ -1,0 +1,32 @@
+(function () {
+    var ip = window.PROBE_IP || '';
+    if (!ip) return;
+    var output = document.getElementById('probe-output');
+    function append(text) {
+        if (!output) return;
+        output.textContent += text + '\n';
+    }
+    var total = 2;
+    var current = 0;
+    loadingOverlay.start('正在进行 Ping 测试');
+    fetch('/ping/' + encodeURIComponent(ip))
+        .then(function (res) { return res.text(); })
+        .then(function (text) {
+            append('Ping 结果:\n' + text + '\n');
+            current++;
+            loadingOverlay.update(current, total, '正在进行 Traceroute 测试');
+            return fetch('/traceroute/' + encodeURIComponent(ip));
+        })
+        .then(function (res) { return res.text(); })
+        .then(function (text) {
+            append('Traceroute 结果:\n' + text + '\n');
+            current++;
+            loadingOverlay.update(current, total, '测试完成');
+        })
+        .catch(function (err) {
+            append('错误: ' + err);
+        })
+        .finally(function () {
+            loadingOverlay.done();
+        });
+})();

--- a/templates/probe.html
+++ b/templates/probe.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>网络探测</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
+</head>
+<body>
+{% include 'loading_overlay.html' %}
+<main style="padding:1rem; font-family:monospace;">
+    <h1>网络探测 - {{ ip }}</h1>
+    <pre id="probe-output" style="white-space:pre-wrap"></pre>
+</main>
+<script>
+    window.PROBE_IP = {{ ip|tojson }};
+</script>
+<script src="{{ url_for('static', filename='js/loading.js') }}"></script>
+<script src="{{ url_for('static', filename='js/probe.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/probe/<ip>` page to run ping and traceroute tests
- show dynamic progress with new `probe.js`
- ensure loading overlay updates messages immediately

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894bc6b0fb8832abd178fc1fcf0aec8