### PR TITLE
feat: warn when origin remote is missing

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,6 +4,12 @@ set -e
 # Always work from the directory containing this script
 cd "$(dirname "$0")"
 
+# Ensure remote repository is configured
+if ! git remote get-url origin >/dev/null 2>&1; then
+  echo "Remote 'origin' not configured; cannot update." >&2
+  exit 1
+fi
+
 # Determine persistent storage location
 if [[ "$OS" == "Windows_NT" ]]; then
   PERSIST_DIR="${USERPROFILE//\\/\//}/Documents/vps-value-calculator"


### PR DESCRIPTION
## Summary
- exit early if `deploy.sh` is run without an `origin` remote to avoid misleading update messages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894bdf0ce14832aa76d23ba32492e5f