### PR TITLE
Remove ping and traceroute hints from loading overlay

### DIFF
--- a/static/css/loading.css
+++ b/static/css/loading.css
@@ -40,13 +40,3 @@
     transition: width 0.3s;
 }
 
-.loading-status {
-    margin-top: 20px;
-    font-size: 1rem;
-    text-align: left;
-}
-
-.loading-status div {
-    margin-top: 4px;
-}
-

--- a/static/js/probe.js
+++ b/static/js/probe.js
@@ -1,51 +1,24 @@
 (function(){
-    const STATUS_IDS = {
-        ping: 'ping-status',
-        traceroute: 'traceroute-status'
-    };
-
-    function setStatus(id, text) {
-        const el = document.getElementById(id);
-        if (el) {
-            el.textContent = text;
-        }
-    }
-
     async function run() {
         const tests = [
-            {
-                id: 'ping',
-                label: 'Ping',
-                run: async () => {
-                    const res = await fetch('/ping/1.1.1.1');
-                    return await res.text();
-                }
+            async () => {
+                const res = await fetch('/ping/1.1.1.1');
+                return await res.text();
             },
-            {
-                id: 'traceroute',
-                label: 'Traceroute',
-                run: async () => {
-                    const res = await fetch('/traceroute/1.1.1.1');
-                    return await res.text();
-                }
+            async () => {
+                const res = await fetch('/traceroute/1.1.1.1');
+                return await res.text();
             }
         ];
 
         loadingOverlay.start('运行网络测试');
 
         for (let i = 0; i < tests.length; i++) {
-            const t = tests[i];
-            const statusId = STATUS_IDS[t.id];
-            setStatus(statusId, t.label + '：测试中...');
+            const test = tests[i];
             try {
-                const result = await t.run();
-                let text = t.label + '：完成';
-                if (t.id === 'ping') {
-                    text += ` (${result})`;
-                }
-                setStatus(statusId, text);
+                await test();
             } catch (err) {
-                setStatus(statusId, t.label + '：失败');
+                // ignore errors
             }
             loadingOverlay.update(i + 1, tests.length);
         }

--- a/templates/loading_overlay.html
+++ b/templates/loading_overlay.html
@@ -1,8 +1,4 @@
 <div id="loading-overlay">
     <div id="loading-text" class="loading-text">Loading</div>
     <div id="loading-bar"><div class="progress"></div></div>
-    <div id="loading-status" class="loading-status">
-        <div id="ping-status"></div>
-        <div id="traceroute-status"></div>
-    </div>
 </div>


### PR DESCRIPTION
## Summary
- remove ping and traceroute status elements from the loading overlay
- drop related status styles and JavaScript updates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895d4514888832ab97493646cb8ea15