### PR TITLE
refactor: make vps cards responsive

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -41,7 +41,8 @@
 
 /* 全局变量 */
 :root {
-  --card-width: 52rem;
+  /* Responsive max card width: min 20rem, preferred 80vw, max 40rem */
+  --card-width: clamp(20rem, 80vw, 40rem);
 }
 
 /* 卡片容器布局 */
@@ -69,8 +70,8 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  width: var(--card-width);
-  max-width: 90vw;
+  width: 100%;
+  max-width: var(--card-width);
   height: auto;
   max-height: 100vh;
   padding: 1rem;


### PR DESCRIPTION
## Summary
- allow card width to adjust responsively using CSS clamp
- use full-width cards capped by max width to avoid layout shifts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899781002e8832a89347bc7fb6a41bb