### PR TITLE
fix: responsive 4-card grid without layout shifts

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -39,12 +39,6 @@
   gap: 1rem;
 }
 
-/* 全局变量 */
-:root {
-  /* Responsive max card width: min 20rem, preferred 80vw, max 40rem */
-  --card-width: clamp(20rem, 80vw, 40rem);
-}
-
 /* 卡片容器布局 */
 .card-container {
   display: flex;
@@ -70,8 +64,9 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  width: 100%;
-  max-width: var(--card-width);
+  flex: 1 1 calc(25% - 1rem);
+  max-width: calc(25% - 1rem);
+  min-width: 250px;
   height: auto;
   max-height: 100vh;
   padding: 1rem;

--- a/static/css/responsive.css
+++ b/static/css/responsive.css
@@ -55,6 +55,8 @@ body {
     box-shadow: 0 0 12px rgba(0, 255, 128, 0.1);
     width: 100%;
     max-width: 100%;
+    flex: 1 1 100%;
+    min-width: 0;
   }
 
   .card-status-tag {


### PR DESCRIPTION
## Summary
- ensure VPS card grid caps at 4 cards per row with responsive widths
- refine mobile styles to keep card widths stable and avoid layout shifts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899830cf8d8832aa4529e46f5fce3d0