### PR TITLE
Style: make VPS cards responsive up to four per row

### DIFF
--- a/static/css/cards.css
+++ b/static/css/cards.css
@@ -40,23 +40,17 @@
 }
 
 /* 卡片容器布局 */
-.card-container {
+.card-wrapper {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
   justify-content: center;
   align-items: stretch;
   padding: 1rem;
-  width: 100%;
-  max-width: 100%;
-  margin: 0 auto;
-  box-sizing: border-box;
-}
-
-.card-wrapper {
   width: 90%;
   max-width: 1600px;
   margin: 0 auto;
+  box-sizing: border-box;
 }
 
 /* 单个卡片样式 */
@@ -170,10 +164,23 @@
   white-space: normal;
 }
 
+@media (max-width: 1200px) {
+  .vps-card {
+    flex: 1 1 calc(33.333% - 1rem);
+    max-width: calc(33.333% - 1rem);
+  }
+}
 
-@media (max-width: 768px) {
-  .card-container {
-    gap: 0.75rem;
-    padding: 0.5rem;
+@media (max-width: 900px) {
+  .vps-card {
+    flex: 1 1 calc(50% - 1rem);
+    max-width: calc(50% - 1rem);
+  }
+}
+
+@media (max-width: 600px) {
+  .vps-card {
+    flex: 1 1 100%;
+    max-width: 100%;
   }
 }

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -53,7 +53,6 @@
     <h1 class="text-center text-4xl font-bold text-cyan-300 mb-8">VPS 列表</h1>
     {% if vps_data %}
     <div class="card-wrapper">
-        <div class="card-container">
         {% for vps, data, specs, ip_info in vps_data %}
         <div class="vps-card relative {% if vps.status == 'sold' %}sold{% elif vps.status == 'inactive' %}inactive{% elif vps.status == 'forsale' %}forsale{% endif %}" data-href="{{ url_for('view_vps', name=vps.name) }}">
             {% if vps.status == 'active' %}
@@ -92,7 +91,6 @@
             </div>
         </div>
         {% endfor %}
-        </div>
     </div>
     {% else %}
     <p class="text-center">暂无 VPS 条目。</p>


### PR DESCRIPTION
## Summary
- Use `.card-wrapper` as flex container and simplify template structure
- Add responsive breakpoints so cards drop to 3/2/1 per row at 1200/900/600px

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899871ba400832a8ada4347d7a4dd74