### PR TITLE
feat(seo): improve indexing for vps page

### DIFF
--- a/app.py
+++ b/app.py
@@ -232,6 +232,17 @@ scheduler.add_job(refresh_ip_info, "interval", minutes=10)
 scheduler.start()
 
 
+@app.route("/robots.txt")
+def robots_txt():
+    lines = [
+        "User-agent: *",
+        "Disallow: /register",
+        "Disallow: /login",
+        "Allow: /vps",
+    ]
+    return Response("\n".join(lines), mimetype="text/plain")
+
+
 @app.route("/register", methods=["GET", "POST"])
 def register():
     if request.method == "POST":

--- a/templates/login.html
+++ b/templates/login.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, nofollow" />
   <title>vps剩余价值计算器</title>
   <script src="https://cdn.tailwindcss.com"></script> <!-- 确保 Tailwind 正常加载 -->
   <style>

--- a/templates/probe.html
+++ b/templates/probe.html
@@ -13,5 +13,9 @@
     <script src="{{ url_for('static', filename='js/loading.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/probe.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/favicon.js') }}" defer></script>
+    <noscript>
+        <meta http-equiv="refresh" content="0; url={{ url_for('vps_list') }}">
+        <p><a href="{{ url_for('vps_list') }}">VPS 列表</a></p>
+    </noscript>
 </body>
 </html>

--- a/templates/register.html
+++ b/templates/register.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, nofollow" />
   <title>vps剩余价值计算器</title>
   <script src="https://cdn.tailwindcss.com"></script> <!-- Tailwind CDN 加载 -->
   <style>

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="VPS剩余价值计算器，快速查看与管理主机信息并计算服务器的剩余价值。">
+    <link rel="canonical" href="{{ url_for('vps_list', _external=True) }}">
     <title>vps剩余价值计算器</title>
     <link rel="preload" href="{{ url_for('static', filename='fonts/JetBrainsMono-Regular.woff2') }}" as="font" type="font/woff2" crossorigin>
     <link rel="preload" href="{{ url_for('static', filename='css/tailwind.css') }}" as="style" onload="this.onload=null;this.rel='stylesheet'">


### PR DESCRIPTION
## Summary
- Add robots.txt route to discourage indexing of register and login pages while allowing /vps
- Mark login and register templates as noindex
- Provide canonical link and non-JS fallback pointing crawlers to VPS list

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aee6d6df0832aae0b2b9a716948dd