### PR TITLE
Add visitor and crawler counters

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -62,3 +62,11 @@ class SiteConfig(Base):
     site_url = Column(String, default="")
     username = Column(String, default="@Flanker")
     copyright = Column(String, default="xxx.com")
+
+
+class VisitStats(Base):
+    __tablename__ = "visit_stats"
+
+    id = Column(Integer, primary_key=True)
+    visitors = Column(Integer, default=0, nullable=False)
+    crawlers = Column(Integer, default=0, nullable=False)

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,5 +1,7 @@
 <footer class="mt-auto w-full h-16 py-4 bg-gray-900 flex items-center justify-center gap-2 text-white text-center">
   <span>© 2025 vvc.428048.xyz</span>
+  <span>Visitors: {{ visit_stats.visitors }}</span>
+  <span>Crawlers: {{ visit_stats.crawlers }}</span>
   <a href="https://github.com/podcctv/vps-value-calculator" target="_blank" aria-label="GitHub repository">
     <img
       src="https://img.shields.io/badge/github-vps_value_calculator-blue"


### PR DESCRIPTION
## Summary
- track visitors and bots via new VisitStats table
- expose visit statistics to templates and display in site footer

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aee84c2c8832a99e8586d205e9537