### PR TITLE
Display footer copyright as badge

### DIFF
--- a/app.py
+++ b/app.py
@@ -205,6 +205,7 @@ def inject_globals():
         "current_user": get_current_user(),
         "config": get_site_config(),
         "site_stats": get_site_stats(),
+        "current_year": datetime.now().year,
     }
 
 

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,5 +1,11 @@
 <footer class="mt-auto w-full h-16 py-4 bg-gray-900 flex items-center justify-center gap-2 text-white text-center">
-  <span>© 2025 vvc.428048.xyz</span>
+  <img
+    src="https://img.shields.io/badge/%C2%A9%20{{ current_year }}-{{ (config.copyright or '') | urlencode }}-blue"
+    alt="Copyright badge"
+    class="h-5"
+    height="20"
+    loading="lazy"
+  />
   <img
     src="https://img.shields.io/badge/Visitors-{{ visit_stats.visitors }}-blue"
     alt="Visitors badge"


### PR DESCRIPTION
## Summary
- Show site copyright as a shield badge in the footer
- Expose current year to templates for dynamic badge generation

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689af2e32df0832a8d18d3871150effd