### PR TITLE
fix: display footer on VPS detail page

### DIFF
--- a/static/css/view_svg.css
+++ b/static/css/view_svg.css
@@ -5,6 +5,7 @@
   align-items: center;
   padding-top: 3rem;
   padding-bottom: 3rem;
+  flex: 1;
 }
 
 .svg-card {

--- a/templates/view_svg.html
+++ b/templates/view_svg.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
 </head>
-<body class="min-h-screen font-mono flex flex-col">
+<body class="bg-gradient-to-br from-[#0f0f1a] to-[#000000] text-white min-h-screen font-mono flex flex-col">
 {% include 'loading_overlay.html' %}
 <nav class="banner">
     <a href="{{ url_for('vps_list') }}" class="banner-home">


### PR DESCRIPTION
## Summary
- ensure VPS detail page uses global background and text style
- allow VPS detail container to grow so footer rests at bottom

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689af5b15ca8832aa1f7e9afd45573b2