### PR TITLE
fix: stabilise layout for badges and cards

### DIFF
--- a/app.py
+++ b/app.py
@@ -86,6 +86,17 @@ def twemoji_filter(emoji: str, width: int = 16, height: int = 16, extra_class: s
     )
 
 
+@app.template_filter("shield_width")
+def shield_width_filter(label: str, message) -> int:
+    """Estimate the width of a shields.io badge.
+
+    This provides a rough width so the browser can reserve space before the
+    image loads, helping to minimise layout shifts for dynamic badges."""
+    base = 80
+    char_width = 8
+    return base + char_width * (len(str(label)) + len(str(message)))
+
+
 app.add_template_filter(twemoji_url, "twemoji_url")
 
 Base.metadata.create_all(bind=engine)

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -3,6 +3,7 @@
     src="https://img.shields.io/badge/%C2%A9%20{{ current_year }}-{{ (config.copyright or '') | urlencode }}-blue"
     alt="Copyright badge"
     class="h-5"
+    width="{{ ('© ' ~ current_year)|shield_width(config.copyright or '') }}"
     height="20"
     loading="lazy"
   />
@@ -10,6 +11,7 @@
     src="https://img.shields.io/badge/Visitors-{{ visit_stats.visitors }}-blue"
     alt="Visitors badge"
     class="h-5"
+    width="{{ 'Visitors'|shield_width(visit_stats.visitors) }}"
     height="20"
     loading="lazy"
   />
@@ -17,6 +19,7 @@
     src="https://img.shields.io/badge/Crawlers-{{ visit_stats.crawlers }}-orange"
     alt="Crawlers badge"
     class="h-5"
+    width="{{ 'Crawlers'|shield_width(visit_stats.crawlers) }}"
     height="20"
     loading="lazy"
   />

--- a/templates/vps.html
+++ b/templates/vps.html
@@ -107,31 +107,31 @@
             if (rect.width > maxWidth) maxWidth = rect.width;
             if (rect.height > maxHeight) maxHeight = rect.height;
         });
-        cards.forEach(card => {
-            card.style.width = `${maxWidth}px`;
-            card.style.height = `${maxHeight}px`;
-            card.style.flex = `0 0 ${maxWidth}px`;
-        });
-    }
+    cards.forEach(card => {
+        card.style.width = `${maxWidth}px`;
+        card.style.minHeight = `${maxHeight}px`;
+        card.style.flex = `0 0 ${maxWidth}px`;
+    });
+}
 
-    function initCards() {
-        unifyCardSizes();
+function initCards() {
+    unifyCardSizes();
         document.querySelectorAll('.vps-card').forEach(card => {
             card.addEventListener('click', () => {
                 window.location.href = card.dataset.href;
             });
         });
-    }
+}
 
-    window.addEventListener('load', initCards);
-    window.addEventListener('resize', () => {
-        document.querySelectorAll('.vps-card').forEach(card => {
-            card.style.width = '';
-            card.style.height = '';
-            card.style.flex = '';
-        });
-        unifyCardSizes();
+document.addEventListener('DOMContentLoaded', initCards);
+window.addEventListener('resize', () => {
+    document.querySelectorAll('.vps-card').forEach(card => {
+        card.style.width = '';
+        card.style.minHeight = '';
+        card.style.flex = '';
     });
+    unifyCardSizes();
+});
 </script>
 {% include 'footer.html' %}
 


### PR DESCRIPTION
## Summary
- estimate shield badge widths to reduce layout shift
- reserve footer badge space with computed width attributes
- size VPS cards on DOM load and use min-height

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689afcd8ba7c832a8ca1b98d83554e8c