### PR TITLE
Adjust IP masking strategy

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -148,10 +148,10 @@ def parse_instance_config(config: str):
 
 
 def mask_ip(ip: str) -> str:
-    """Mask the middle two octets of an IPv4 address.
+    """Mask the last two octets of an IPv4 address.
 
     Any port information or extra text is stripped before masking so that an
-    input like ``"1.2.3.4:5678"`` will be rendered as ``"1.**.**.4"``.
+    input like ``"1.2.3.4:5678"`` will be rendered as ``"1.2.**.**"``.
     """
     import re
 
@@ -161,7 +161,7 @@ def mask_ip(ip: str) -> str:
         return ip.split(":")[0]
     clean_ip = match.group(0)
     parts = clean_ip.split(".")
-    return f"{parts[0]}.**.**.{parts[3]}"
+    return f"{parts[0]}.{parts[1]}.**.**"
 
 
 _ping_cache = {}

--- a/tests/test_mask_ip.py
+++ b/tests/test_mask_ip.py
@@ -1,0 +1,25 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+spec = importlib.util.spec_from_file_location("app_main", ROOT / "app.py")
+app_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(app_module)
+mask_ip = app_module.mask_ip
+
+
+def test_mask_ip_masks_last_two_octets():
+    assert mask_ip("192.168.10.1") == "192.168.**.**"
+
+
+def test_mask_ip_strips_port_before_masking():
+    assert mask_ip("10.0.0.1:8080") == "10.0.**.**"
+
+
+def test_mask_ip_without_ipv4_falls_back_to_host():
+    assert mask_ip("example.com:1234") == "example.com"


### PR DESCRIPTION
## Summary
- update IPv4 masking to hide the final two octets and align with expected display format
- keep port-stripping behavior so masked output remains clean
- add regression tests covering the updated masking logic and non-IPv4 fallbacks

## Testing
- pytest tests/test_mask_ip.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e92ae7f0c832ab5ad3e777f01be9c)